### PR TITLE
Add requirements TOML and setup script

### DIFF
--- a/requirements.toml
+++ b/requirements.toml
@@ -1,0 +1,7 @@
+[python]
+dependencies = [
+  "pandas",
+  "gpxpy",
+  "shapely",
+  "rtree"
+]

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# Determine path to requirements.toml relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REQ_FILE="$SCRIPT_DIR/../requirements.toml"
+
+if [ ! -f "$REQ_FILE" ]; then
+  echo "Requirements file not found: $REQ_FILE" >&2
+  exit 1
+fi
+
+# Parse dependencies from the TOML file using python
+packages=$(python - <<PY
+import tomllib
+import sys
+with open('$REQ_FILE', 'rb') as f:
+    data = tomllib.load(f)
+packages = data.get('python', {}).get('dependencies', [])
+print(' '.join(packages))
+PY
+)
+
+if [ -z "$packages" ]; then
+  echo "No packages found in $REQ_FILE" >&2
+  exit 1
+fi
+
+pip install $packages
+


### PR DESCRIPTION
## Summary
- specify Python dependencies in `requirements.toml`
- add `run/setup.sh` to install dependencies from the TOML file

## Testing
- `run/setup.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68477e162f9c83299240aa9ea6e9a9b7