### PR TITLE
Add pip install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # boise-trails-ai
 Trying to find my personal optimal route for the Boise Trails Challenge
 
+## Installation
+
+Dependencies are defined in `requirements.toml`.  For convenience a matching
+`requirements.txt` is kept in sync so you can install directly with `pip`:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Alternatively you can run the provided helper script which reads
+`requirements.toml` and installs the same dependencies:
+
+```bash
+bash run/setup.sh
+```
+
 ## GPX to CSV utility
 
 Convert a season of GPX activity files into a consolidated `segment_perf.csv`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+gpxpy
+shapely
+rtree


### PR DESCRIPTION
## Summary
- clarify that requirements.toml is canonical
- note requirements.txt is kept in sync for convenience

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68478058b27c8329b8cc0d419b8688c4