### PR TITLE
Add daily route planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ GPX files are expected under `data/gpx/<YEAR>/`. Segment definitions must be
 available as `data/traildata/trail.json`. Running the
 script appends matching segment performances to `data/segment_perf.csv`. Use
 `--rebuild` to drop any existing rows for that year before processing.
+
+## Daily route planner
+
+Generate a loop route that fits within a time budget. Example usage:
+
+```bash
+python scripts/daily_planner.py --time 90 --pace 10 --grade 30
+```
+
+The planner loads segment definitions from `data/traildata/trail.json` and uses
+any completions found in `data/segment_perf.csv` to prioritize new segments.

--- a/scripts/daily_planner.py
+++ b/scripts/daily_planner.py
@@ -1,0 +1,132 @@
+import argparse
+import json
+import os
+from collections import defaultdict, namedtuple
+from typing import List, Dict, Tuple, Set
+
+
+Edge = namedtuple('Edge', ['seg_id', 'name', 'start', 'end', 'length_mi', 'elev_gain_ft'])
+
+
+def load_segments(path: str) -> List[Edge]:
+    with open(path) as f:
+        data = json.load(f)
+    if 'trailSegments' in data:
+        seg_list = data['trailSegments']
+    elif 'segments' in data:
+        seg_list = data['segments']
+    elif 'features' in data:
+        seg_list = [f.get('properties', {}) | {'geometry': f['geometry']} for f in data['features']]
+    else:
+        raise ValueError('Unrecognized segment JSON structure')
+    edges = []
+    for seg in seg_list:
+        props = seg.get('properties', seg)
+        coords = seg['geometry']['coordinates'] if 'geometry' in seg else seg['coordinates']
+        start = tuple(round(c, 6) for c in coords[0])
+        end = tuple(round(c, 6) for c in coords[-1])
+        length_ft = float(props.get('LengthFt', 0))
+        elev_gain = float(props.get('elevGainFt', 0) or props.get('ElevGainFt', 0) or 0)
+        seg_id = props.get('segId') or props.get('id') or props.get('seg_id')
+        name = props.get('segName') or props.get('name') or ''
+        length_mi = length_ft / 5280.0
+        edge = Edge(seg_id, name, start, end, length_mi, elev_gain)
+        edges.append(edge)
+    return edges
+
+
+def build_graph(edges: List[Edge]):
+    graph: Dict[Tuple[float, float], List[Tuple[Edge, Tuple[float, float]]]] = defaultdict(list)
+    for e in edges:
+        graph[e.start].append((e, e.end))
+        graph[e.end].append((e, e.start))
+    return graph
+
+
+def estimate_time(edge: Edge, pace_min_per_mi: float, grade_factor_sec_per_100ft: float) -> float:
+    base = edge.length_mi * pace_min_per_mi
+    penalty = (edge.elev_gain_ft / 100.0) * (grade_factor_sec_per_100ft / 60.0)
+    return base + penalty
+
+
+def load_completed(csv_path: str, year: int) -> Set:
+    if not os.path.exists(csv_path):
+        return set()
+    import pandas as pd
+    df = pd.read_csv(csv_path)
+    df = df[df.year == year]
+    return set(df.seg_id.astype(str).unique())
+
+
+def search_loops(graph, start, pace, grade, time_budget, completed, max_depth=5):
+    best = None
+    visited: Set[Tuple[str, Tuple[float, float], Tuple[float, float]]] = set()
+
+    def dfs(node, time_so_far, path, used_segments):
+        nonlocal best
+        if node == start and path:
+            new_count = len({e.seg_id for e in used_segments if e.seg_id not in completed})
+            if best is None or new_count > best['new_count'] or (new_count == best['new_count'] and time_so_far < best['time']):
+                best = {'path': list(used_segments), 'time': time_so_far, 'new_count': new_count}
+            # continue exploring for possibly better loops
+        if len(used_segments) >= max_depth:
+            return
+        for edge, nxt in graph[node]:
+            key = (edge.seg_id, node, nxt)
+            if key in visited:
+                continue
+            seg_time = estimate_time(edge, pace, grade)
+            if time_so_far + seg_time > time_budget:
+                continue
+            visited.add(key)
+            used_segments.append(edge)
+            dfs(nxt, time_so_far + seg_time, path + [edge], used_segments)
+            used_segments.pop()
+            visited.remove(key)
+
+    dfs(start, 0.0, [], [])
+    return best
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Daily route planner")
+    parser.add_argument('--time', type=float, required=True, help='Time budget in minutes')
+    parser.add_argument('--pace', type=float, required=True, help='Base pace in minutes per mile')
+    parser.add_argument('--grade', type=float, default=0.0, help='Additional seconds per 100ft of climb per mile')
+    parser.add_argument('--segments', default='data/traildata/trail.json')
+    parser.add_argument('--perf', default='data/segment_perf.csv')
+    parser.add_argument('--year', type=int, default=2024)
+    parser.add_argument('--start-seg', type=str, help='Segment ID to start from')
+    parser.add_argument('--max-depth', type=int, default=5)
+    args = parser.parse_args(argv)
+
+    edges = load_segments(args.segments)
+    graph = build_graph(edges)
+
+    completed = load_completed(args.perf, args.year)
+
+    start_node = None
+    if args.start_seg:
+        for e in edges:
+            if str(e.seg_id) == args.start_seg:
+                start_node = e.start
+                break
+    if start_node is None:
+        # default: start at first edge start
+        start_node = edges[0].start
+
+    result = search_loops(graph, start_node, args.pace, args.grade, args.time, completed, max_depth=args.max_depth)
+    if not result:
+        print('No loop found within time budget')
+        return
+    total_distance = sum(e.length_mi for e in result['path'])
+    print('Selected segments:')
+    for e in result['path']:
+        print(f"  {e.seg_id} - {e.name}")
+    print(f"Total new segments: {result['new_count']}")
+    print(f"Total distance: {total_distance:.2f} mi")
+    print(f"Estimated time: {result['time']:.1f} min")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_daily_planner.py
+++ b/tests/test_daily_planner.py
@@ -1,0 +1,30 @@
+from scripts import daily_planner
+
+
+def build_sample_edges():
+    # simple triangle A-B-C-A
+    edges = [
+        daily_planner.Edge('A', 'A-B', (-1.0, 0.0), (0.0, 0.0), 1.0, 0.0),
+        daily_planner.Edge('B', 'B-C', (0.0, 0.0), (0.0, 1.0), 1.0, 0.0),
+        daily_planner.Edge('C', 'C-A', (0.0, 1.0), (-1.0, 0.0), 1.0, 0.0),
+    ]
+    return edges
+
+
+def test_simple_loop():
+    edges = build_sample_edges()
+    graph = daily_planner.build_graph(edges)
+    result = daily_planner.search_loops(
+        graph,
+        edges[0].start,
+        pace=10.0,
+        grade=0.0,
+        time_budget=40.0,
+        completed=set(),
+        max_depth=5,
+    )
+    assert result is not None
+    assert len(result['path']) == 3
+    assert result['new_count'] == 3
+    assert abs(result['time'] - 30.0) < 1e-6
+


### PR DESCRIPTION
## Summary
- implement a simple daily route planner with a greedy loop search
- expose utility via `scripts/daily_planner.py`
- add tests for planner
- document the new feature in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a4d1b4d48329ab0fea1b64697e0b