### PR TITLE
Add GPX export for daily planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,12 @@ Generate a loop route that fits within a time budget. Example usage:
 python scripts/daily_planner.py --time 90 --pace 10 --grade 30
 ```
 
+Optionally write the selected loop as a GPX file:
+
+```bash
+python scripts/daily_planner.py --time 90 --pace 10 --grade 30 \
+    --gpx-output my_route.gpx
+```
+
 The planner loads segment definitions from `data/traildata/trail.json` and uses
 any completions found in `data/segment_perf.csv` to prioritize new segments.

--- a/tests/test_daily_planner.py
+++ b/tests/test_daily_planner.py
@@ -4,9 +4,12 @@ from scripts import daily_planner
 def build_sample_edges():
     # simple triangle A-B-C-A
     edges = [
-        daily_planner.Edge('A', 'A-B', (-1.0, 0.0), (0.0, 0.0), 1.0, 0.0),
-        daily_planner.Edge('B', 'B-C', (0.0, 0.0), (0.0, 1.0), 1.0, 0.0),
-        daily_planner.Edge('C', 'C-A', (0.0, 1.0), (-1.0, 0.0), 1.0, 0.0),
+        daily_planner.Edge('A', 'A-B', (-1.0, 0.0), (0.0, 0.0), 1.0, 0.0,
+                          [(-1.0, 0.0), (0.0, 0.0)]),
+        daily_planner.Edge('B', 'B-C', (0.0, 0.0), (0.0, 1.0), 1.0, 0.0,
+                          [(0.0, 0.0), (0.0, 1.0)]),
+        daily_planner.Edge('C', 'C-A', (0.0, 1.0), (-1.0, 0.0), 1.0, 0.0,
+                          [(0.0, 1.0), (-1.0, 0.0)]),
     ]
     return edges
 
@@ -31,7 +34,8 @@ def test_simple_loop():
 
 def test_reuse_only_to_close():
     """Single segment should be allowed twice only when closing the loop."""
-    edge = daily_planner.Edge('X', 'A-B', (0.0, 0.0), (1.0, 0.0), 1.0, 0.0)
+    edge = daily_planner.Edge('X', 'A-B', (0.0, 0.0), (1.0, 0.0), 1.0, 0.0,
+                              [(0.0, 0.0), (1.0, 0.0)])
     graph = daily_planner.build_graph([edge])
     result = daily_planner.search_loops(
         graph,
@@ -50,7 +54,8 @@ def test_reuse_only_to_close():
 def test_maximize_unique_segments():
     edges = build_sample_edges()
     # add reverse edge allowing a short loop with repeated ID
-    edges.append(daily_planner.Edge('A', 'B-A', (0.0, 0.0), (-1.0, 0.0), 1.0, 0.0))
+    edges.append(daily_planner.Edge('A', 'B-A', (0.0, 0.0), (-1.0, 0.0), 1.0, 0.0,
+                                   [(0.0, 0.0), (-1.0, 0.0)]))
     graph = daily_planner.build_graph(edges)
     result = daily_planner.search_loops(
         graph,


### PR DESCRIPTION
## Summary
- extend `Edge` namedtuple with `coords`
- write `write_gpx` function to serialize a route
- add `--gpx-output` option to `daily_planner.py`
- document GPX output in README
- update tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847acfbb988832981fd0c858494fba8