### PR TITLE
Enhance daily planner output and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ python scripts/daily_planner.py --time 90 --pace 10 --grade 30
 
 The planner loads segment definitions from `data/traildata/trail.json` and uses
 any completions found in `data/segment_perf.csv` to prioritize new segments.
+
+Additional options include:
+
+* `--trailhead` – starting trailhead specified as `lon,lat`. If omitted the
+  planner tries every available trailhead and picks the one that yields the most
+  new segments within the time budget.
+* `--gpx-output` – path to save a GPX file of the planned loop.
+
+Example generating a GPX route:
+
+```bash
+python scripts/daily_planner.py --time 90 --pace 10 --grade 30 \
+    --gpx-output my_route.gpx
+```

--- a/tests/test_daily_planner.py
+++ b/tests/test_daily_planner.py
@@ -4,9 +4,9 @@ from scripts import daily_planner
 def build_sample_edges():
     # simple triangle A-B-C-A
     edges = [
-        daily_planner.Edge('A', 'A-B', (-1.0, 0.0), (0.0, 0.0), 1.0, 0.0),
-        daily_planner.Edge('B', 'B-C', (0.0, 0.0), (0.0, 1.0), 1.0, 0.0),
-        daily_planner.Edge('C', 'C-A', (0.0, 1.0), (-1.0, 0.0), 1.0, 0.0),
+        daily_planner.Edge('A', 'A-B', (-1.0, 0.0), (0.0, 0.0), 1.0, 0.0, [(-1.0, 0.0), (0.0, 0.0)]),
+        daily_planner.Edge('B', 'B-C', (0.0, 0.0), (0.0, 1.0), 1.0, 0.0, [(0.0, 0.0), (0.0, 1.0)]),
+        daily_planner.Edge('C', 'C-A', (0.0, 1.0), (-1.0, 0.0), 1.0, 0.0, [(0.0, 1.0), (-1.0, 0.0)]),
     ]
     return edges
 
@@ -31,7 +31,7 @@ def test_simple_loop():
 
 def test_reuse_only_to_close():
     """Single segment should be allowed twice only when closing the loop."""
-    edge = daily_planner.Edge('X', 'A-B', (0.0, 0.0), (1.0, 0.0), 1.0, 0.0)
+    edge = daily_planner.Edge('X', 'A-B', (0.0, 0.0), (1.0, 0.0), 1.0, 0.0, [(0.0, 0.0), (1.0, 0.0)])
     graph = daily_planner.build_graph([edge])
     result = daily_planner.search_loops(
         graph,
@@ -50,7 +50,7 @@ def test_reuse_only_to_close():
 def test_maximize_unique_segments():
     edges = build_sample_edges()
     # add reverse edge allowing a short loop with repeated ID
-    edges.append(daily_planner.Edge('A', 'B-A', (0.0, 0.0), (-1.0, 0.0), 1.0, 0.0))
+    edges.append(daily_planner.Edge('A', 'B-A', (0.0, 0.0), (-1.0, 0.0), 1.0, 0.0, [(0.0, 0.0), (-1.0, 0.0)]))
     graph = daily_planner.build_graph(edges)
     result = daily_planner.search_loops(
         graph,


### PR DESCRIPTION
## Summary
- compute loop distance, gain and time and output route summary
- add --trailhead and --gpx-output options
- automatically pick best trailhead when none is specified
- write GPX file for the final loop
- update tests for new Edge signature
- document new CLI options and automatic trailhead selection

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847acee0e78832990ef420594af33d9