### PR TITLE
Enhance time parsing in daily planner

### DIFF
--- a/scripts/daily_planner.py
+++ b/scripts/daily_planner.py
@@ -194,10 +194,26 @@ def _close(
     return abs(a[0] - b[0]) <= tol and abs(a[1] - b[1]) <= tol
 
 
+def parse_time_budget(value: str) -> float:
+    """Parse a time specification and return minutes.
+
+    Accepts plain minutes ("90"), hours with ``h`` suffix ("1.5h"), or
+    ``H:MM`` notation ("1:30").
+    """
+
+    text = value.strip().lower()
+    if text.endswith("h"):
+        return float(text[:-1]) * 60.0
+    if ":" in text:
+        hrs, mins = text.split(":", 1)
+        return float(hrs) * 60.0 + float(mins)
+    return float(text)
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Daily route planner")
     parser.add_argument(
-        "--time", type=float, required=True, help="Time budget in minutes"
+        "--time", type=str, required=True, help="Time budget (minutes, 'h' suffix, or H:MM)"
     )
     parser.add_argument(
         "--pace",
@@ -233,6 +249,8 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
+    time_budget = parse_time_budget(args.time)
+
     edges = load_segments(args.segments)
     graph = build_graph(edges)
 
@@ -244,7 +262,7 @@ def main(argv=None):
             node,
             args.pace,
             args.grade,
-            args.time,
+            time_budget,
             completed,
             max_segments=args.max_segments,
         )

--- a/tests/test_daily_planner.py
+++ b/tests/test_daily_planner.py
@@ -162,3 +162,30 @@ def test_write_gpx(tmp_path):
                 expected.extend(seg_coords)
     assert pts == expected
 
+
+@pytest.mark.parametrize("inp,minutes", [
+    ("90", 90.0),
+    ("1.5h", 90.0),
+    ("1:30", 90.0),
+])
+def test_parse_time_budget(inp, minutes):
+    assert daily_planner.parse_time_budget(inp) == minutes
+
+
+@pytest.mark.parametrize("fmt", ["90", "1.5h", "1:30"])
+def test_cli_time_formats(fmt, two_clusters, monkeypatch, capsys):
+    seg_path, perf_path = two_clusters
+    monkeypatch.chdir(seg_path.parent)
+    daily_planner.main([
+        "--time",
+        fmt,
+        "--pace",
+        "10",
+        "--segments",
+        str(seg_path),
+        "--perf",
+        str(perf_path),
+    ])
+    out = capsys.readouterr().out
+    assert "Route Summary" in out
+


### PR DESCRIPTION
## Summary
- support flexible time specifications like `1.5h` and `1:30`
- parse `--time` as a string and convert using new helper
- test new `parse_time_budget` formats and CLI support

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b146786c8329bdacd89765d8e021