### PR TITLE
Improve loop selection with repeated segment awareness

### DIFF
--- a/scripts/daily_planner.py
+++ b/scripts/daily_planner.py
@@ -100,21 +100,31 @@ def search_loops(
         nonlocal best
 
         if node == start and path:
-            new_count = len(
-                {e.seg_id for e in path if e.seg_id not in completed}
-            )
+            seg_ids = {e.seg_id for e in path}
+            new_ids = {sid for sid in seg_ids if sid not in completed}
+            repeat_ids = seg_ids - new_ids
+            new_count = len(new_ids)
+            repeat_count = len(repeat_ids)
             if (
                 best is None
                 or new_count > best["new_count"]
                 or (
                     new_count == best["new_count"]
-                    and time_so_far < best["time"]
+                    and (
+                        repeat_count < best.get("repeat_count", float("inf"))
+                        or (
+                            repeat_count
+                            == best.get("repeat_count", float("inf"))
+                            and time_so_far < best["time"]
+                        )
+                    )
                 )
             ):
                 best = {
                     "path": list(path),
                     "time": time_so_far,
                     "new_count": new_count,
+                    "repeat_count": repeat_count,
                 }
             # continue exploring for possibly better loops
 
@@ -276,7 +286,15 @@ def main(argv=None):
                 or r["new_count"] > best_res["new_count"]
                 or (
                     r["new_count"] == best_res["new_count"]
-                    and r["time"] < best_res["time"]
+                    and (
+                        r.get("repeat_count", float("inf"))
+                        < best_res.get("repeat_count", float("inf"))
+                        or (
+                            r.get("repeat_count", float("inf"))
+                            == best_res.get("repeat_count", float("inf"))
+                            and r["time"] < best_res["time"]
+                        )
+                    )
                 )
             ):
                 best_res = r

--- a/tests/test_daily_planner.py
+++ b/tests/test_daily_planner.py
@@ -162,3 +162,42 @@ def test_write_gpx(tmp_path):
                 expected.extend(seg_coords)
     assert pts == expected
 
+
+def test_tiebreak_fewer_completed_segments():
+    edges = build_sample_edges()
+    # longer two-segment loop without completed segments
+    edges.extend(
+        [
+            daily_planner.Edge(
+                "D",
+                "A-C2",
+                (-1.0, 0.0),
+                (0.0, 1.0),
+                2.0,
+                0.0,
+                [(-1.0, 0.0), (0.0, 1.0)],
+            ),
+            daily_planner.Edge(
+                "E",
+                "C-A2",
+                (0.0, 1.0),
+                (-1.0, 0.0),
+                2.0,
+                0.0,
+                [(0.0, 1.0), (-1.0, 0.0)],
+            ),
+        ]
+    )
+    graph = daily_planner.build_graph(edges)
+    result = daily_planner.search_loops(
+        graph,
+        edges[0].start,
+        pace=10.0,
+        grade=0.0,
+        time_budget=60.0,
+        completed={"A", "C"},
+        max_segments=3,
+    )
+    seg_ids = [e.seg_id for e in result["path"]]
+    assert seg_ids == ["D", "E"]
+


### PR DESCRIPTION
## Summary
- track how many loop segments were already completed
- pick loops with fewer completed segments when new_count ties
- add test for the tie-break behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b14d79088329892256e5d94af22e