### PR TITLE
Fix monthly planner import handling

### DIFF
--- a/scripts/monthly_planner.py
+++ b/scripts/monthly_planner.py
@@ -1,12 +1,17 @@
 import argparse
 import csv
 import os
+import sys
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
 import numpy as np
 from sklearn.cluster import KMeans
 import networkx as nx
+
+# Allow running this file directly without installing the package
+if __package__ in (None, ""):
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from scripts import daily_planner
 


### PR DESCRIPTION
## Summary
- fix monthly_planner so it works when run as a script

## Testing
- `pytest -q`
- `python scripts/monthly_planner.py --time 1h --pace 10 --grade 30 --year 2024 --output sample_plan2.csv --gpx-dir sample_gpx2`

------
https://chatgpt.com/codex/tasks/task_e_68482742fe5c83299f82f62e2f2b63a4