### PR TITLE
Add plan column with segment names to monthly plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ python scripts/monthly_planner.py --time 1h --pace 10 --grade 30 --year 2024
 
 This produces a summary table `monthly_plan.csv` and GPX files under the `gpx/`
 directory (one file per day).  The summary lists the segments scheduled for each
-day along with distance, elevation gain, and estimated time.
+day along with distance, elevation gain, estimated time, and a human readable
+"plan" column describing the trail names in order.
 
 Re-run the planner after recording new segment completions (for example by
 updating `data/segment_perf.csv` with `gpx_to_csv.py`).  Only unfinished

--- a/scripts/monthly_planner.py
+++ b/scripts/monthly_planner.py
@@ -193,6 +193,7 @@ def main(argv=None):
         summary_rows.append({
             "day": day,
             "segments": " ".join(str(e.seg_id) for e in cluster),
+            "plan": " > ".join(e.name or str(e.seg_id) for e in route),
             "distance_mi": round(dist, 2),
             "elev_gain_ft": round(gain, 0),
             "time_min": round(est_time, 1),

--- a/tests/test_monthly_planner.py
+++ b/tests/test_monthly_planner.py
@@ -75,6 +75,7 @@ def test_planner_outputs(tmp_path):
             for pt in seg.points
         ]
         assert pts[0] == pts[-1]
+        assert "plan" in row and row["plan"]
 
 
 def test_completed_excluded(tmp_path):


### PR DESCRIPTION
## Summary
- include human readable trail plan in `monthly_plan.csv`
- document the plan column in README
- test that the planner outputs the new column

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684830513188832984541e23515741c7