### PR TITLE
Fix bounding box format for pyrosm

### DIFF
--- a/clip_roads.py
+++ b/clip_roads.py
@@ -18,7 +18,9 @@ def buffered_bbox(geojson_path: str, buffer_km: float = 3.0):
     km_per_deg_lat = 111.32
     dx = buffer_km / km_per_deg_lon
     dy = buffer_km / km_per_deg_lat
-    return (minx - dx, miny - dy, maxx + dx, maxy + dy)
+    # pyrosm expects the bounding box as a list, not a tuple, so return it in
+    # that form
+    return [minx - dx, miny - dy, maxx + dx, maxy + dy]
 
 
 def clip_roads(


### PR DESCRIPTION
## Summary
- ensure `buffered_bbox` returns a list instead of a tuple

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848614058b88329800d96a0cf34b441