### PR TITLE
Add data download script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 
 # Data files
 /data/gpx/
+/data/osm/*
+!/data/osm/.gitkeep

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Alternatively you can run the provided helper script which reads
 bash run/setup.sh
 ```
 
+## Download data assets
+
+External datasets used by the project are not committed to the repository.
+Run the helper script below to fetch them:
+
+```bash
+bash run/get_data.sh
+```
+
+This currently downloads `idaho-latest.osm.pbf` from Geofabrik and stores it
+under `data/osm/`.
+
 ## GPX to CSV utility
 
 Convert a season of GPX activity files into a consolidated `segment_perf.csv`:
@@ -73,20 +85,21 @@ for this step.)
 ```bash
 pip install pyrosm geopandas shapely fiona
 python clip_roads.py \
-    --pbf idaho-latest.osm.pbf \
+    --pbf data/osm/idaho-latest.osm.pbf \
     --trails Boise_Parks_Trails_Open_Data.geojson \
     --out data/boise_roads.geojson --buffer_km 3
 ```
 
-The command downloads `idaho-latest.osm.pbf` separately and writes a much smaller
-`boise_roads.geojson` that can be committed to the repository.
+The example assumes `data/osm/idaho-latest.osm.pbf` has been downloaded using
+`run/get_data.sh`. It writes a much smaller `boise_roads.geojson` that can be
+committed to the repository.
 
 Use `--buffer_km` to shrink the bounding box if the output is too large. You can
 also limit the data further:
 
 ```bash
 python clip_roads.py \
-    --pbf idaho-latest.osm.pbf \
+    --pbf data/osm/idaho-latest.osm.pbf \
     --trails Boise_Parks_Trails_Open_Data.geojson \
     --out data/boise_roads.geojson \
     --buffer_km 1 \

--- a/run/get_data.sh
+++ b/run/get_data.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Directory for downloaded assets relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="$SCRIPT_DIR/../data/osm"
+mkdir -p "$DATA_DIR"
+
+PBF_URL="https://download.geofabrik.de/north-america/us/idaho-latest.osm.pbf"
+PBF_FILE="$DATA_DIR/idaho-latest.osm.pbf"
+
+if [ -f "$PBF_FILE" ]; then
+  echo "OSM PBF already exists: $PBF_FILE"
+else
+  echo "Downloading Idaho OSM data..."
+  curl -L "$PBF_URL" -o "$PBF_FILE"
+fi
+


### PR DESCRIPTION
## Summary
- add `run/get_data.sh` for downloading external data
- store OSM downloads under `data/osm/`
- ignore downloaded files in git except for `.gitkeep`
- document download step and update `clip_roads.py` examples

## Testing
- `bash run/setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486a887b548329b528bf20ea03e83a