### PR TITLE
Add road connector routing

### DIFF
--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -31,7 +31,7 @@ def write_segments(path, edges):
 def test_cluster_limit(count):
     edges = build_edges(count)
     clusters = challenge_planner.cluster_segments(
-        edges, pace=10.0, grade=0.0, budget=30.0, max_clusters=30
+        edges, pace=10.0, grade=0.0, budget=30.0, max_clusters=30, road_pace=18.0
     )
     assert len(clusters) <= 30
 


### PR DESCRIPTION
## Summary
- support road connectors in route planning
- add road pace and max road distance CLI options
- compute road segment distances with haversine
- adjust clustering and tests for new parameter

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486c37343483298603b2a78e94fa32