### PR TITLE
Add SRTM elevation data script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 /data/gpx/
 /data/osm/*
 !/data/osm/.gitkeep
+# Ignore locally generated DEM tiles
+/data/*.tif

--- a/README.md
+++ b/README.md
@@ -115,3 +115,19 @@ python clip_roads.py \
 The `--highways` flag keeps only the listed highway categories and `--columns`
 drops unused attributes to keep the GeoJSON compact.
 
+## Download SRTM DEM
+
+Elevation profiles and grade calculations rely on a small digital
+elevation model.  Run `clip_srtm.py` once to download the necessary
+SRTM tiles and crop them to the trail envelope:
+
+```bash
+pip install elevation rasterio geopandas shapely
+./clip_srtm.py \
+    --trails data/traildata/Boise_Parks_Trails_Open_Data.geojson \
+    --out data/srtm_boise_clipped.tif --buffer_km 3
+```
+
+The resulting `srtm_boise_clipped.tif` is only a few megabytes and is ignored
+by Git. Keep it locally or regenerate it as needed.
+

--- a/clip_srtm.py
+++ b/clip_srtm.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Download and clip SRTM elevation data for the Boise Foothills."""
+
+import argparse
+from pathlib import Path
+
+import geopandas as gpd
+from shapely.ops import unary_union
+import elevation
+import rasterio
+from rasterio.mask import mask
+
+
+def clip_srtm(trails_path: str, out_path: str = "srtm_boise_clipped.tif", buffer_km: float = 3.0) -> Path:
+    """Download SRTM tiles touching the buffered trails and clip them."""
+    gdf = gpd.read_file(trails_path)
+    minx, miny, maxx, maxy = gdf.total_bounds
+    # Rough degrees per km at mid-latitude
+    deg = buffer_km / 111.32
+    minx -= deg
+    miny -= deg
+    maxx += deg
+    maxy += deg
+    from shapely.geometry import box
+    bbox = (minx, miny, maxx, maxy)
+    area = box(minx, miny, maxx, maxy)
+
+    out_path = Path(out_path).resolve()
+    elevation.clip(bounds=(minx, miny, maxx, maxy), output=str(out_path))
+
+    with rasterio.open(out_path) as src:
+        out_img, transform = mask(src, [area.__geo_interface__], crop=True)
+        out_meta = src.meta.copy()
+        out_meta.update({"transform": transform, "height": out_img.shape[1], "width": out_img.shape[2], "compress": "lzw"})
+
+    with rasterio.open(out_path, "w", **out_meta) as dst:
+        dst.write(out_img)
+
+    size_mb = out_path.stat().st_size / 1e6
+    print(f"Final DEM saved: {size_mb:.1f} MB -> {out_path}")
+    return out_path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trails", required=True, help="Boise trails GeoJSON")
+    parser.add_argument(
+        "--out", default="srtm_boise_clipped.tif", help="Output GeoTIFF path"
+    )
+    parser.add_argument(
+        "--buffer_km", type=float, default=3.0, help="Buffer beyond trail bbox"
+    )
+    args = parser.parse_args(argv)
+
+    clip_srtm(args.trails, args.out, args.buffer_km)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `clip_srtm.py` to fetch and crop SRTM tiles
- document how to create the DEM
- store the clipped DEM under `data/`
- removed large binary DEM from repo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68489e58e13c832987f1c812761bc0be