### PR TITLE
Annotate road connectors in GPX

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Passing `--roads` allows the planner to use short road connectors. Use
 `--max-road` to limit the mileage of any road link (default 1 mile) and
 `--road-threshold` to control how much faster a road must be compared to the
 all-trail option before it is chosen (default 0.1 for 10% faster).
+Use `--mark-road-transitions` if you would like GPX output to highlight road
+sections with waypoints and track segment metadata.
 
 Re-run the planner after recording new segment completions (for example by
 updating `data/segment_perf.csv` with `gpx_to_csv.py`). Only unfinished segments

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,10 @@ This list tracks potential future enhancements and areas for improvement for the
 
 6.  **Visual Distinction of Road Connectors in GPX:**
     *   The user story suggests marking road connectors distinctly in GPX files.
-    *   *TODO: Investigate adding waypoints with notes, or using GPX track segment extensions, to denote transitions to/from road connector sections if this is a high-priority feature for users. Compatibility with various GPX software should be considered.*
+    *   Implemented via the ``--mark-road-transitions`` flag. When enabled, GPX files
+        contain separate track segments labelled ``trail`` or ``road`` and include
+        waypoints at the start and end of each road connector for compatibility with
+        basic GPX viewers.
 
 ## Data & Performance
 

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -283,6 +283,11 @@ def main(argv=None):
     parser.add_argument("--remaining")
     parser.add_argument("--output", default="challenge_plan.csv")
     parser.add_argument("--gpx-dir", default="gpx")
+    parser.add_argument(
+        "--mark-road-transitions",
+        action="store_true",
+        help="Annotate GPX files with waypoints and track extensions for road sections",
+    )
     parser.add_argument("--average-driving-speed-mph", type=float, default=30.0, help="Average driving speed in mph for estimating travel time between activity clusters.")
     parser.add_argument("--max-drive-minutes-per-transfer", type=float, default=30.0, help="Maximum allowed driving time in minutes for a single transfer between activity clusters on the same day.")
     args = parser.parse_args(argv)
@@ -470,7 +475,9 @@ def main(argv=None):
 
                 gpx_file_name = f"{day_plan['date'].strftime('%Y%m%d')}_part{gpx_part_counter}.gpx"
                 gpx_path = os.path.join(args.gpx_dir, gpx_file_name)
-                planner_utils.write_gpx(gpx_path, route)
+                planner_utils.write_gpx(
+                    gpx_path, route, mark_road_transitions=args.mark_road_transitions
+                )
 
                 trail_segment_ids_in_route = sorted(list(set(str(e.seg_id) for e in route if e.kind == 'trail' and e.seg_id)))
                 part_desc = f"{activity_name} (Segs: {', '.join(trail_segment_ids_in_route)}; {dist:.2f}mi; {gain:.0f}ft; {est_activity_time:.1f}min)"


### PR DESCRIPTION
## Summary
- add optional `--mark-road-transitions` flag to challenge planner
- enhance `write_gpx` to split road/trail segments and insert waypoints when marking transitions
- document the new flag and update TODO
- adjust planner tests for updated CSV columns and GPX output
- test GPX annotations for road sections

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b15c8890832996cd20f4a93a2db0