### PR TITLE
Add cleanup step for SRTM download

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ SRTM tiles and crop them to the trail envelope:
 
 ```bash
 pip install elevation rasterio geopandas shapely
+# GDAL utilities are required by the `elevation` package
+# On Debian/Ubuntu you can install them with:
+#   apt-get install gdal-bin
+# If the process fails, remove any zero-byte tiles and try again:
+#   python -c "import elevation; elevation.clean()"
 ./clip_srtm.py \
     --trails data/traildata/Boise_Parks_Trails_Open_Data.geojson \
     --out data/srtm_boise_clipped.tif --buffer_km 3

--- a/clip_srtm.py
+++ b/clip_srtm.py
@@ -30,6 +30,9 @@ def clip_srtm(
     area = box(minx, miny, maxx, maxy)
 
     out_path = Path(out_path).resolve()
+    # Remove any leftover zero-byte files from earlier failures so the
+    # `elevation` Makefile rebuilds the tiles correctly.
+    elevation.clean()
     elevation.clip(bounds=(minx, miny, maxx, maxy), output=str(out_path))
 
     with rasterio.open(out_path) as src:

--- a/requirements.toml
+++ b/requirements.toml
@@ -7,5 +7,6 @@ dependencies = [
   "networkx",
   "scikit-learn",
   "numpy",
-  "rasterio"
+  "rasterio",
+  "elevation"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ networkx
 scikit-learn
 rasterio
 numpy
+elevation


### PR DESCRIPTION
## Summary
- call `elevation.clean()` before clipping tiles
- document how to clean stale SRTM files when GDAL was missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848baaf79d483299f79295784b0e2b6