### PR TITLE
Add multiday GPX creation

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -575,6 +575,16 @@ def main(argv=None):
             # writer.writerow({field: "N/A" for field in default_fieldnames})
             # writer.writerow({"date": "N/A", "plan_description": "No activities planned"})
 
+    if daily_plans and any(dp.get("activities") for dp in daily_plans):
+        colors = ["Red", "Blue", "Green", "Magenta", "Cyan", "Orange", "Purple", "Brown"]
+        full_gpx_path = os.path.join(args.gpx_dir, "full_timespan.gpx")
+        planner_utils.write_multiday_gpx(
+            full_gpx_path,
+            daily_plans,
+            mark_road_transitions=args.mark_road_transitions,
+            colors=colors,
+        )
+
 
     print(f"Challenge plan written to {args.output}")
     if not daily_plans or not any(dp.get("activities") for dp in daily_plans) : # Check if any activities were actually planned


### PR DESCRIPTION
## Summary
- support converting edges to GPX segments via `_segments_from_edges`
- generate a combined multiday GPX file with `write_multiday_gpx`
- produce the multiday file from the planner
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f67c876c832984ba357276f9c0ab