### PR TITLE
Remove clip_roads references

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Alternatively you can run the provided helper script which reads
 ```bash
 bash run/setup.sh
 ```
-
 ## Download data assets
 
 External datasets used by the project are not committed to the repository.
@@ -95,10 +94,6 @@ python -m trail_route_ai.challenge_planner \
     --roads data/osm/idaho-latest.osm.pbf \
     ...
 ```
-
-If you prefer a smaller dataset you can still create your own clipped GeoJSON
-using external tools, but the previously bundled ``clip_roads.py`` script has
-been removed.
 
 ## Download SRTM DEM
 

--- a/trail_route_ai_demo.ipynb
+++ b/trail_route_ai_demo.ipynb
@@ -175,7 +175,7 @@
     },
     {
       "cell_type": "markdown",
-      "source": "This notebook walked through setting up the environment, downloading necessary data, running the street map clipper (`clip_roads.py`), preparing data for the challenge planner, and finally generating a trail running schedule (`challenge_planner.py`).\n\nYou can now explore the generated `challenge_plan_output.csv` and the GPX files in the `gpx_output_colab` directory. Feel free to modify the parameters in the code cells (e.g., dates, time per session, pace) and re-run the notebook to experiment further with the Trail Route AI planner.",
+      "source": "This notebook walked through setting up the environment, downloading necessary data, loading the full road dataset, preparing data for the challenge planner, and finally generating a trail running schedule (`challenge_planner.py`).\n\nYou can now explore the generated `challenge_plan_output.csv` and the GPX files in the `gpx_output_colab` directory. Feel free to modify the parameters in the code cells (e.g., dates, time per session, pace) and re-run the notebook to experiment further with the Trail Route AI planner.",
       "metadata": {
         "id": "22"
       }


### PR DESCRIPTION
## Summary
- drop references to clip_roads.py from README and demo notebook
- describe using the full OSM roads file in the notebook

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684981ce5cb0832981e0f8929e71466b