### PR TITLE
Restore required imports

### DIFF
--- a/tests/test_gpx_to_csv.py
+++ b/tests/test_gpx_to_csv.py
@@ -2,6 +2,7 @@ import os
 import json
 import datetime
 import pandas as pd
+import pytest
 from trail_route_ai import gpx_to_csv
 
 


### PR DESCRIPTION
## Summary
- revert skipping logic in tests
- install gpxpy/pandas to exercise code paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849838938e08329be73994bbf4aa0a9