### PR TITLE
Improve planner status output

### DIFF
--- a/requirements.toml
+++ b/requirements.toml
@@ -10,4 +10,5 @@ dependencies = [
   "rasterio",
   "elevation",
   "pyrosm"
+  , "tqdm"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ rasterio
 numpy
 elevation
 pyrosm
+tqdm


### PR DESCRIPTION
## Summary
- suppress repeated error messages during cluster planning
- show progress bars with `tqdm`
- remove verbose flag and always print routing errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `gpxpy` and `pandas`)*

------
https://chatgpt.com/codex/tasks/task_e_684987b8c10c8329b4e05e6e1b9beca4