### PR TITLE
Add default planner config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,29 @@ python -m trail_route_ai.challenge_planner --start-date 2024-07-01 --end-date 20
     --output plans/challenge.csv --gpx-dir plans/gpx
 ```
 
+### Using a configuration file
+
+Many of the command line options can be provided in a JSON file and loaded with
+the `--config` flag:
+
+```json
+{
+  "start_date": "2024-07-01",
+  "end_date": "2024-07-31",
+  "time": "1h",
+  "pace": 10,
+  "grade": 30,
+  "gpx_dir": "plans/gpx",
+  "output": "plans/challenge.csv"
+}
+```
+
+Run the planner with:
+
+```bash
+python -m trail_route_ai.challenge_planner --config planner_config.json
+```
+
 ## Road connectors
 
 Road connectors can now be loaded directly from the full Idaho OSM PBF that

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@ This list tracks potential future enhancements and areas for improvement for the
 
 5.  **User Preferences for Routing:**
     *   The user story mentions preferences like “avoid busy roads” or “prefer trails even if longer.”
-    *   *TODO: Design and implement a mechanism for users to specify routing preferences (e.g., via a configuration file or new command-line arguments). This would require road/trail segments to have relevant metadata (e.g., "busy," "scenic") and pathfinding algorithms to consider these weighted preferences.*
+    *   Basic JSON configuration file support allows specifying default arguments. Future work may incorporate per-segment preference weights once metadata such as “busy” or “scenic” becomes available.
 
 6.  **Visual Distinction of Road Connectors in GPX:**
     *   The user story suggests marking road connectors distinctly in GPX files.

--- a/planner_config.json
+++ b/planner_config.json
@@ -1,0 +1,9 @@
+{
+  "start_date": "2025-06-19",
+  "end_date": "2025-07-18",
+  "time": "1h",
+  "pace": 10,
+  "grade": 30,
+  "gpx_dir": "gpx",
+  "output": "challenge_plan.csv"
+}


### PR DESCRIPTION
## Summary
- add a `planner_config.json` file with sample defaults for the planner

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498836f6408329b2a4a14ed493324c