### PR TITLE
Enhance segment tracking schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ loaded automatically to provide default values for command line arguments:
 
 No command line flag is required.
 
-Segment completion is tracked in `segment_tracking.json`. The file maps each
-segment ID to a boolean indicating whether it has been completed. If the file
-does not exist it will be created with all segments marked as incomplete.
+Segment completion and metadata are tracked in `segment_tracking.json`.  Each
+segment ID maps to an object with a ``completed`` flag, ``name`` for the trail
+segment and an optional ``minutes`` mapping of previous years to the time in
+minutes.  If the file does not exist it will be created automatically with all
+segments marked as incomplete.
 
 The planner does not extend beyond the configured start and end dates. If daily
 time budgets are exceeded to fit all segments within the range, a note is added

--- a/segment_tracking.json
+++ b/segment_tracking.json
@@ -1,249 +1,1237 @@
 {
-  "699": false,
-  "700": false,
-  "702": false,
-  "703": false,
-  "704": false,
-  "705": false,
-  "706": false,
-  "707": false,
-  "708": false,
-  "709": false,
-  "710": false,
-  "711": false,
-  "712": false,
-  "713": false,
-  "714": false,
-  "716": false,
-  "717": false,
-  "718": false,
-  "719": false,
-  "720": false,
-  "721": false,
-  "722": false,
-  "723": false,
-  "724": false,
-  "725": false,
-  "726": false,
-  "727": false,
-  "728": false,
-  "729": false,
-  "730": false,
-  "731": false,
-  "732": false,
-  "733": false,
-  "734": false,
-  "735": false,
-  "736": false,
-  "737": false,
-  "738": false,
-  "739": false,
-  "740": false,
-  "741": false,
-  "742": false,
-  "743": false,
-  "744": false,
-  "745": false,
-  "746": false,
-  "747": false,
-  "748": false,
-  "749": false,
-  "750": false,
-  "751": false,
-  "752": false,
-  "753": false,
-  "755": false,
-  "756": false,
-  "757": false,
-  "758": false,
-  "759": false,
-  "760": false,
-  "761": false,
-  "762": false,
-  "763": false,
-  "764": false,
-  "765": false,
-  "766": false,
-  "773": false,
-  "774": false,
-  "775": false,
-  "776": false,
-  "777": false,
-  "778": false,
-  "779": false,
-  "780": false,
-  "781": false,
-  "782": false,
-  "786": false,
-  "787": false,
-  "788": false,
-  "789": false,
-  "790": false,
-  "791": false,
-  "792": false,
-  "793": false,
-  "794": false,
-  "795": false,
-  "796": false,
-  "797": false,
-  "798": false,
-  "799": false,
-  "800": false,
-  "801": false,
-  "802": false,
-  "803": false,
-  "804": false,
-  "805": false,
-  "806": false,
-  "807": false,
-  "808": false,
-  "809": false,
-  "810": false,
-  "811": false,
-  "812": false,
-  "813": false,
-  "814": false,
-  "815": false,
-  "816": false,
-  "817": false,
-  "818": false,
-  "821": false,
-  "822": false,
-  "823": false,
-  "824": false,
-  "825": false,
-  "826": false,
-  "827": false,
-  "828": false,
-  "829": false,
-  "830": false,
-  "831": false,
-  "832": false,
-  "833": false,
-  "834": false,
-  "835": false,
-  "836": false,
-  "837": false,
-  "838": false,
-  "839": false,
-  "840": false,
-  "841": false,
-  "842": false,
-  "843": false,
-  "844": false,
-  "845": false,
-  "846": false,
-  "847": false,
-  "848": false,
-  "849": false,
-  "851": false,
-  "852": false,
-  "853": false,
-  "854": false,
-  "855": false,
-  "856": false,
-  "857": false,
-  "858": false,
-  "859": false,
-  "860": false,
-  "861": false,
-  "862": false,
-  "863": false,
-  "864": false,
-  "865": false,
-  "866": false,
-  "867": false,
-  "868": false,
-  "869": false,
-  "870": false,
-  "871": false,
-  "872": false,
-  "873": false,
-  "874": false,
-  "875": false,
-  "879": false,
-  "880": false,
-  "881": false,
-  "882": false,
-  "883": false,
-  "884": false,
-  "885": false,
-  "886": false,
-  "887": false,
-  "888": false,
-  "889": false,
-  "890": false,
-  "891": false,
-  "892": false,
-  "893": false,
-  "894": false,
-  "895": false,
-  "896": false,
-  "897": false,
-  "898": false,
-  "899": false,
-  "900": false,
-  "901": false,
-  "902": false,
-  "903": false,
-  "904": false,
-  "905": false,
-  "906": false,
-  "907": false,
-  "908": false,
-  "909": false,
-  "910": false,
-  "911": false,
-  "912": false,
-  "913": false,
-  "914": false,
-  "915": false,
-  "916": false,
-  "917": false,
-  "918": false,
-  "919": false,
-  "920": false,
-  "921": false,
-  "922": false,
-  "923": false,
-  "924": false,
-  "925": false,
-  "926": false,
-  "927": false,
-  "928": false,
-  "929": false,
-  "930": false,
-  "931": false,
-  "932": false,
-  "933": false,
-  "934": false,
-  "935": false,
-  "936": false,
-  "937": false,
-  "938": false,
-  "1182": false,
-  "1183": false,
-  "1184": false,
-  "1185": false,
-  "1186": false,
-  "1187": false,
-  "1188": false,
-  "1189": false,
-  "1190": false,
-  "1191": false,
-  "1192": false,
-  "1193": false,
-  "1194": false,
-  "1195": false,
-  "1196": false,
-  "1197": false,
-  "1198": false,
-  "1199": false,
-  "1200": false,
-  "1201": false,
-  "1202": false,
-  "1203": false,
-  "1204": false,
-  "1205": false,
-  "1206": false
+  "699": {
+    "completed": false,
+    "name": "15th St. Trail 1",
+    "minutes": {}
+  },
+  "700": {
+    "completed": false,
+    "name": "36th Street Chute 1",
+    "minutes": {}
+  },
+  "702": {
+    "completed": false,
+    "name": "8th Street Motorcycle Trail 1",
+    "minutes": {}
+  },
+  "703": {
+    "completed": false,
+    "name": "8th Street Motorcycle Trail 2",
+    "minutes": {}
+  },
+  "704": {
+    "completed": false,
+    "name": "8th Street Motorcycle Trail 3",
+    "minutes": {}
+  },
+  "705": {
+    "completed": false,
+    "name": "8th Street Motorcycle Trail 4",
+    "minutes": {}
+  },
+  "706": {
+    "completed": false,
+    "name": "8th Street Motorcycle Trail 5",
+    "minutes": {}
+  },
+  "707": {
+    "completed": false,
+    "name": "Around the Mountain Trail 1",
+    "minutes": {}
+  },
+  "708": {
+    "completed": false,
+    "name": "Around the Mountain Trail 2",
+    "minutes": {}
+  },
+  "709": {
+    "completed": false,
+    "name": "Around the Mountain Trail 3",
+    "minutes": {}
+  },
+  "710": {
+    "completed": false,
+    "name": "Around the Mountain Trail 4",
+    "minutes": {}
+  },
+  "711": {
+    "completed": false,
+    "name": "Around the Mountain Trail 5",
+    "minutes": {}
+  },
+  "712": {
+    "completed": false,
+    "name": "Barn Owl 1",
+    "minutes": {}
+  },
+  "713": {
+    "completed": false,
+    "name": "Barn Owl 2",
+    "minutes": {}
+  },
+  "714": {
+    "completed": false,
+    "name": "Big Springs 1",
+    "minutes": {}
+  },
+  "716": {
+    "completed": false,
+    "name": "Bitterbrush Trail 1",
+    "minutes": {}
+  },
+  "717": {
+    "completed": false,
+    "name": "Bob's Trail 1",
+    "minutes": {}
+  },
+  "718": {
+    "completed": false,
+    "name": "Bob's Trail 2",
+    "minutes": {}
+  },
+  "719": {
+    "completed": false,
+    "name": "Bob's Trail 3",
+    "minutes": {}
+  },
+  "720": {
+    "completed": false,
+    "name": "Brewers Byway 1",
+    "minutes": {}
+  },
+  "721": {
+    "completed": false,
+    "name": "Brewers Byway 3",
+    "minutes": {}
+  },
+  "722": {
+    "completed": false,
+    "name": "Buena Vista Trail 1",
+    "minutes": {}
+  },
+  "723": {
+    "completed": false,
+    "name": "Buena Vista Trail 2",
+    "minutes": {}
+  },
+  "724": {
+    "completed": false,
+    "name": "Buena Vista Trail 3",
+    "minutes": {}
+  },
+  "725": {
+    "completed": false,
+    "name": "Cartwright Ridge 1",
+    "minutes": {}
+  },
+  "726": {
+    "completed": false,
+    "name": "Cartwright Ridge 2",
+    "minutes": {}
+  },
+  "727": {
+    "completed": false,
+    "name": "Central Ridge Trail 1",
+    "minutes": {}
+  },
+  "728": {
+    "completed": false,
+    "name": "Central Ridge Trail 2",
+    "minutes": {}
+  },
+  "729": {
+    "completed": false,
+    "name": "Central Ridge Trail 3",
+    "minutes": {}
+  },
+  "730": {
+    "completed": false,
+    "name": "CHBH Connector 1",
+    "minutes": {}
+  },
+  "731": {
+    "completed": false,
+    "name": "Chickadee Ridge Trail 1",
+    "minutes": {}
+  },
+  "732": {
+    "completed": false,
+    "name": "Chickadee Ridge Trail 2",
+    "minutes": {}
+  },
+  "733": {
+    "completed": false,
+    "name": "Chukar Butte Trail 1",
+    "minutes": {}
+  },
+  "734": {
+    "completed": false,
+    "name": "Chukar Butte Trail 2",
+    "minutes": {}
+  },
+  "735": {
+    "completed": false,
+    "name": "Chukar Butte Trail 3",
+    "minutes": {}
+  },
+  "736": {
+    "completed": false,
+    "name": "Connection (Eagle Ridge) 1",
+    "minutes": {}
+  },
+  "737": {
+    "completed": false,
+    "name": "Connector 1",
+    "minutes": {}
+  },
+  "738": {
+    "completed": false,
+    "name": "Corrals Trail 1",
+    "minutes": {}
+  },
+  "739": {
+    "completed": false,
+    "name": "Corrals Trail 2",
+    "minutes": {}
+  },
+  "740": {
+    "completed": false,
+    "name": "Corrals Trail 3",
+    "minutes": {}
+  },
+  "741": {
+    "completed": false,
+    "name": "Corrals Trail 4",
+    "minutes": {}
+  },
+  "742": {
+    "completed": false,
+    "name": "Corrals Trail 5",
+    "minutes": {}
+  },
+  "743": {
+    "completed": false,
+    "name": "Cottonwood Creek Trail 1",
+    "minutes": {}
+  },
+  "744": {
+    "completed": false,
+    "name": "Cottonwood Creek Trail 2",
+    "minutes": {}
+  },
+  "745": {
+    "completed": false,
+    "name": "Cottonwood Creek Trail 3",
+    "minutes": {}
+  },
+  "746": {
+    "completed": false,
+    "name": "Crestline Trail 1",
+    "minutes": {}
+  },
+  "747": {
+    "completed": false,
+    "name": "Crestline Trail 2",
+    "minutes": {}
+  },
+  "748": {
+    "completed": false,
+    "name": "Crestline Trail 3",
+    "minutes": {}
+  },
+  "749": {
+    "completed": false,
+    "name": "Crestline Trail 4",
+    "minutes": {}
+  },
+  "750": {
+    "completed": false,
+    "name": "Currant Creek 1",
+    "minutes": {}
+  },
+  "751": {
+    "completed": false,
+    "name": "Currant Creek 2",
+    "minutes": {}
+  },
+  "752": {
+    "completed": false,
+    "name": "Currant Creek 3",
+    "minutes": {}
+  },
+  "753": {
+    "completed": false,
+    "name": "D's Chaos 1",
+    "minutes": {}
+  },
+  "755": {
+    "completed": false,
+    "name": "Deer Point Trail 1",
+    "minutes": {}
+  },
+  "756": {
+    "completed": false,
+    "name": "Doe Ridge 1",
+    "minutes": {}
+  },
+  "757": {
+    "completed": false,
+    "name": "Dry Creek Trail 1",
+    "minutes": {}
+  },
+  "758": {
+    "completed": false,
+    "name": "Dry Creek Trail 2",
+    "minutes": {}
+  },
+  "759": {
+    "completed": false,
+    "name": "Dry Creek Trail 3",
+    "minutes": {}
+  },
+  "760": {
+    "completed": false,
+    "name": "Dry Creek Trail 4",
+    "minutes": {}
+  },
+  "761": {
+    "completed": false,
+    "name": "Dry Creek Trail 5",
+    "minutes": {}
+  },
+  "762": {
+    "completed": false,
+    "name": "Dry Creek Trail 6",
+    "minutes": {}
+  },
+  "763": {
+    "completed": false,
+    "name": "Eagle Ridge Trail 1",
+    "minutes": {}
+  },
+  "764": {
+    "completed": false,
+    "name": "Eagle Ridge Trail 2",
+    "minutes": {}
+  },
+  "765": {
+    "completed": false,
+    "name": "Eagle Ridge Trail 3",
+    "minutes": {}
+  },
+  "766": {
+    "completed": false,
+    "name": "Eagle Ridge Trail 4",
+    "minutes": {}
+  },
+  "773": {
+    "completed": false,
+    "name": "Elephant Rock Loop 1",
+    "minutes": {}
+  },
+  "774": {
+    "completed": false,
+    "name": "Elk Meadows Trail 1",
+    "minutes": {}
+  },
+  "775": {
+    "completed": false,
+    "name": "Elk Meadows Trail 2",
+    "minutes": {}
+  },
+  "776": {
+    "completed": false,
+    "name": "Fat Tire Traverse 1",
+    "minutes": {}
+  },
+  "777": {
+    "completed": false,
+    "name": "Femrite's Patrol 1",
+    "minutes": {}
+  },
+  "778": {
+    "completed": false,
+    "name": "Femrite's Patrol 2",
+    "minutes": {}
+  },
+  "779": {
+    "completed": false,
+    "name": "Femrite's Patrol 4",
+    "minutes": {}
+  },
+  "780": {
+    "completed": false,
+    "name": "Five Mile Gulch Trail 1",
+    "minutes": {}
+  },
+  "781": {
+    "completed": false,
+    "name": "Five Mile Gulch Trail 2",
+    "minutes": {}
+  },
+  "782": {
+    "completed": false,
+    "name": "Five Mile Gulch Trail 3",
+    "minutes": {}
+  },
+  "786": {
+    "completed": false,
+    "name": "Freestone Ridge 1",
+    "minutes": {}
+  },
+  "787": {
+    "completed": false,
+    "name": "Freestone Ridge 2",
+    "minutes": {}
+  },
+  "788": {
+    "completed": false,
+    "name": "Full Sail Trail 1",
+    "minutes": {}
+  },
+  "789": {
+    "completed": false,
+    "name": "Full Sail Trail 2",
+    "minutes": {}
+  },
+  "790": {
+    "completed": false,
+    "name": "Gold Finch 1",
+    "minutes": {}
+  },
+  "791": {
+    "completed": false,
+    "name": "Gold Finch 2",
+    "minutes": {}
+  },
+  "792": {
+    "completed": false,
+    "name": "Hard Guy Trail 1",
+    "minutes": {}
+  },
+  "793": {
+    "completed": false,
+    "name": "Hard Guy Trail 2",
+    "minutes": {}
+  },
+  "794": {
+    "completed": false,
+    "name": "Hawkins 1",
+    "minutes": {}
+  },
+  "795": {
+    "completed": false,
+    "name": "Hawkins 2",
+    "minutes": {}
+  },
+  "796": {
+    "completed": false,
+    "name": "Hawkins 3",
+    "minutes": {}
+  },
+  "797": {
+    "completed": false,
+    "name": "Heroes Trail 1",
+    "minutes": {}
+  },
+  "798": {
+    "completed": false,
+    "name": "Heroes Trail 2",
+    "minutes": {}
+  },
+  "799": {
+    "completed": false,
+    "name": "Highlands Trail 1",
+    "minutes": {}
+  },
+  "800": {
+    "completed": false,
+    "name": "Highlands Trail 2",
+    "minutes": {}
+  },
+  "801": {
+    "completed": false,
+    "name": "Hippie Shake Trail 1",
+    "minutes": {}
+  },
+  "802": {
+    "completed": false,
+    "name": "Kemper's Ridge Trail 1",
+    "minutes": {}
+  },
+  "803": {
+    "completed": false,
+    "name": "Kemper's Ridge Trail 2",
+    "minutes": {}
+  },
+  "804": {
+    "completed": false,
+    "name": "Kemper's Ridge Trail 3",
+    "minutes": {}
+  },
+  "805": {
+    "completed": false,
+    "name": "Kemper's Ridge Trail 4",
+    "minutes": {}
+  },
+  "806": {
+    "completed": false,
+    "name": "Kestral Trail 1",
+    "minutes": {}
+  },
+  "807": {
+    "completed": false,
+    "name": "Landslide 1",
+    "minutes": {}
+  },
+  "808": {
+    "completed": false,
+    "name": "Lower Hull's Gulch Trail 1",
+    "minutes": {}
+  },
+  "809": {
+    "completed": false,
+    "name": "Lower Hull's Gulch Trail 2",
+    "minutes": {}
+  },
+  "810": {
+    "completed": false,
+    "name": "Lower Hull's Gulch Trail 3",
+    "minutes": {}
+  },
+  "811": {
+    "completed": false,
+    "name": "Lower Hull's Gulch Trail 4",
+    "minutes": {}
+  },
+  "812": {
+    "completed": false,
+    "name": "Lower Hull's Gulch Trail 5",
+    "minutes": {}
+  },
+  "813": {
+    "completed": false,
+    "name": "Mahalo Trail 1",
+    "minutes": {}
+  },
+  "814": {
+    "completed": false,
+    "name": "Military Reserve Connection 1",
+    "minutes": {}
+  },
+  "815": {
+    "completed": false,
+    "name": "Mountain Cove 1",
+    "minutes": {}
+  },
+  "816": {
+    "completed": false,
+    "name": "Mountain Cove 2",
+    "minutes": {}
+  },
+  "817": {
+    "completed": false,
+    "name": "Mountain Cove 3",
+    "minutes": {}
+  },
+  "818": {
+    "completed": false,
+    "name": "Mountain Cove 4",
+    "minutes": {}
+  },
+  "821": {
+    "completed": false,
+    "name": "Orchard Gulch Trail 1",
+    "minutes": {}
+  },
+  "822": {
+    "completed": false,
+    "name": "Owl's Roost 1",
+    "minutes": {}
+  },
+  "823": {
+    "completed": false,
+    "name": "Peggy's Trail 1",
+    "minutes": {}
+  },
+  "824": {
+    "completed": false,
+    "name": "Quarry Trail - Castle Rock 1",
+    "minutes": {}
+  },
+  "825": {
+    "completed": false,
+    "name": "Quarry Trail - Castle Rock 2",
+    "minutes": {}
+  },
+  "826": {
+    "completed": false,
+    "name": "Quarry Trail - Castle Rock 3",
+    "minutes": {}
+  },
+  "827": {
+    "completed": false,
+    "name": "Quarry Trail - Castle Rock 4",
+    "minutes": {}
+  },
+  "828": {
+    "completed": false,
+    "name": "Quarry Trail - Castle Rock 5",
+    "minutes": {}
+  },
+  "829": {
+    "completed": false,
+    "name": "Quick Draw 1",
+    "minutes": {}
+  },
+  "830": {
+    "completed": false,
+    "name": "Rabbit Run 1",
+    "minutes": {}
+  },
+  "831": {
+    "completed": false,
+    "name": "Rabbit Run 2",
+    "minutes": {}
+  },
+  "832": {
+    "completed": false,
+    "name": "Rabbit Run 3",
+    "minutes": {}
+  },
+  "833": {
+    "completed": false,
+    "name": "Rabbit Run 4",
+    "minutes": {}
+  },
+  "834": {
+    "completed": false,
+    "name": "Red Cliffs 1",
+    "minutes": {}
+  },
+  "835": {
+    "completed": false,
+    "name": "Red Cliffs 2",
+    "minutes": {}
+  },
+  "836": {
+    "completed": false,
+    "name": "Red Tail Trail 1",
+    "minutes": {}
+  },
+  "837": {
+    "completed": false,
+    "name": "Red Tail Trail 2",
+    "minutes": {}
+  },
+  "838": {
+    "completed": false,
+    "name": "Red Tail Trail 3",
+    "minutes": {}
+  },
+  "839": {
+    "completed": false,
+    "name": "Red Tail Trail 4",
+    "minutes": {}
+  },
+  "840": {
+    "completed": false,
+    "name": "Red Tail Trail 5",
+    "minutes": {}
+  },
+  "841": {
+    "completed": false,
+    "name": "Red Tail Trail 6",
+    "minutes": {}
+  },
+  "842": {
+    "completed": false,
+    "name": "Red Tail Trail 7",
+    "minutes": {}
+  },
+  "843": {
+    "completed": false,
+    "name": "Red Tail Trail 8",
+    "minutes": {}
+  },
+  "844": {
+    "completed": false,
+    "name": "REI Connection 1",
+    "minutes": {}
+  },
+  "845": {
+    "completed": false,
+    "name": "Ricochet 1",
+    "minutes": {}
+  },
+  "846": {
+    "completed": false,
+    "name": "Ridge Crest 2",
+    "minutes": {}
+  },
+  "847": {
+    "completed": false,
+    "name": "Ridge Crest 1",
+    "minutes": {}
+  },
+  "848": {
+    "completed": false,
+    "name": "Rock Garden 1",
+    "minutes": {}
+  },
+  "849": {
+    "completed": false,
+    "name": "Rock Island 1",
+    "minutes": {}
+  },
+  "851": {
+    "completed": false,
+    "name": "Rock Island 2",
+    "minutes": {}
+  },
+  "852": {
+    "completed": false,
+    "name": "Rock Island 3",
+    "minutes": {}
+  },
+  "853": {
+    "completed": false,
+    "name": "Rock Island 4",
+    "minutes": {}
+  },
+  "854": {
+    "completed": false,
+    "name": "Rock Island 5",
+    "minutes": {}
+  },
+  "855": {
+    "completed": false,
+    "name": "Rock Island 6",
+    "minutes": {}
+  },
+  "856": {
+    "completed": false,
+    "name": "Rock Island 7",
+    "minutes": {}
+  },
+  "857": {
+    "completed": false,
+    "name": "Rock Island 8",
+    "minutes": {}
+  },
+  "858": {
+    "completed": false,
+    "name": "Scott's Trail 1",
+    "minutes": {}
+  },
+  "859": {
+    "completed": false,
+    "name": "Seaman Gulch Trail 1",
+    "minutes": {}
+  },
+  "860": {
+    "completed": false,
+    "name": "Seaman Gulch Trail 2",
+    "minutes": {}
+  },
+  "861": {
+    "completed": false,
+    "name": "Seaman Gulch Trail 3",
+    "minutes": {}
+  },
+  "862": {
+    "completed": false,
+    "name": "Seaman Gulch Trail 4",
+    "minutes": {}
+  },
+  "863": {
+    "completed": false,
+    "name": "Seaman Gulch Trail 5",
+    "minutes": {}
+  },
+  "864": {
+    "completed": false,
+    "name": "Shane's Trail 1",
+    "minutes": {}
+  },
+  "865": {
+    "completed": false,
+    "name": "Shane's Trail 2",
+    "minutes": {}
+  },
+  "866": {
+    "completed": false,
+    "name": "Shane's Trail 3",
+    "minutes": {}
+  },
+  "867": {
+    "completed": false,
+    "name": "Shane's Connector 1",
+    "minutes": {}
+  },
+  "868": {
+    "completed": false,
+    "name": "Sheep Camp Trail 1",
+    "minutes": {}
+  },
+  "869": {
+    "completed": false,
+    "name": "Shindig 1",
+    "minutes": {}
+  },
+  "870": {
+    "completed": false,
+    "name": "Shindig 2",
+    "minutes": {}
+  },
+  "871": {
+    "completed": false,
+    "name": "Shingle Creek Trail 1",
+    "minutes": {}
+  },
+  "872": {
+    "completed": false,
+    "name": "Shooting Range 1",
+    "minutes": {}
+  },
+  "873": {
+    "completed": false,
+    "name": "Shoshone-Paiute 1",
+    "minutes": {}
+  },
+  "874": {
+    "completed": false,
+    "name": "Shoshone-Paiute 2",
+    "minutes": {}
+  },
+  "875": {
+    "completed": false,
+    "name": "Sidewinder Trail 1",
+    "minutes": {}
+  },
+  "879": {
+    "completed": false,
+    "name": "Spring Creek 1",
+    "minutes": {}
+  },
+  "880": {
+    "completed": false,
+    "name": "Stack Rock Connector 1",
+    "minutes": {}
+  },
+  "881": {
+    "completed": false,
+    "name": "Stack Rock Connector 2",
+    "minutes": {}
+  },
+  "882": {
+    "completed": false,
+    "name": "Sweet Connie Trail 1",
+    "minutes": {}
+  },
+  "883": {
+    "completed": false,
+    "name": "Sweet Connie Trail 2",
+    "minutes": {}
+  },
+  "884": {
+    "completed": false,
+    "name": "Sweet Connie Trail 3",
+    "minutes": {}
+  },
+  "885": {
+    "completed": false,
+    "name": "Table Rock Quarry Trail 1",
+    "minutes": {}
+  },
+  "886": {
+    "completed": false,
+    "name": "Table Rock Quarry Trail 2",
+    "minutes": {}
+  },
+  "887": {
+    "completed": false,
+    "name": "Table Rock Trail 1",
+    "minutes": {}
+  },
+  "888": {
+    "completed": false,
+    "name": "Table Rock Trail 2",
+    "minutes": {}
+  },
+  "889": {
+    "completed": false,
+    "name": "Table Rock Trail 3",
+    "minutes": {}
+  },
+  "890": {
+    "completed": false,
+    "name": "Table Rock Trail 4",
+    "minutes": {}
+  },
+  "891": {
+    "completed": false,
+    "name": "Table Rock Trail 5",
+    "minutes": {}
+  },
+  "892": {
+    "completed": false,
+    "name": "Table Rock Trail 6",
+    "minutes": {}
+  },
+  "893": {
+    "completed": false,
+    "name": "Table Rock Trail 7",
+    "minutes": {}
+  },
+  "894": {
+    "completed": false,
+    "name": "Tempest Trail 1",
+    "minutes": {}
+  },
+  "895": {
+    "completed": false,
+    "name": "Tempest Trail 2",
+    "minutes": {}
+  },
+  "896": {
+    "completed": false,
+    "name": "The Face Trail 1",
+    "minutes": {}
+  },
+  "897": {
+    "completed": false,
+    "name": "Three Bears Trail 1",
+    "minutes": {}
+  },
+  "898": {
+    "completed": false,
+    "name": "Three Bears Trail 2",
+    "minutes": {}
+  },
+  "899": {
+    "completed": false,
+    "name": "Three Bears Trail 3",
+    "minutes": {}
+  },
+  "900": {
+    "completed": false,
+    "name": "Three Bears Trail 4",
+    "minutes": {}
+  },
+  "901": {
+    "completed": false,
+    "name": "Three Bears Trail 5",
+    "minutes": {}
+  },
+  "902": {
+    "completed": false,
+    "name": "Tram Trail 1",
+    "minutes": {}
+  },
+  "903": {
+    "completed": false,
+    "name": "Twisted Spring 1",
+    "minutes": {}
+  },
+  "904": {
+    "completed": false,
+    "name": "Twisted Spring 2",
+    "minutes": {}
+  },
+  "905": {
+    "completed": false,
+    "name": "Twisted Spring 3",
+    "minutes": {}
+  },
+  "906": {
+    "completed": false,
+    "name": "Urban Connector 1",
+    "minutes": {}
+  },
+  "907": {
+    "completed": false,
+    "name": "Veterans 1",
+    "minutes": {}
+  },
+  "908": {
+    "completed": false,
+    "name": "Veterans 2",
+    "minutes": {}
+  },
+  "909": {
+    "completed": false,
+    "name": "Veterans 3",
+    "minutes": {}
+  },
+  "910": {
+    "completed": false,
+    "name": "Watchman Trail 1",
+    "minutes": {}
+  },
+  "911": {
+    "completed": false,
+    "name": "Watchman Trail 2",
+    "minutes": {}
+  },
+  "912": {
+    "completed": false,
+    "name": "Whistling Pig 1",
+    "minutes": {}
+  },
+  "913": {
+    "completed": false,
+    "name": "Who Now Loop Trail 1",
+    "minutes": {}
+  },
+  "914": {
+    "completed": false,
+    "name": "Who Now Loop Trail 2",
+    "minutes": {}
+  },
+  "915": {
+    "completed": false,
+    "name": "Who Now Loop Trail 3",
+    "minutes": {}
+  },
+  "916": {
+    "completed": false,
+    "name": "Wild Phlox Trail 1",
+    "minutes": {}
+  },
+  "917": {
+    "completed": false,
+    "name": "Wild Phlox Trail 2",
+    "minutes": {}
+  },
+  "918": {
+    "completed": false,
+    "name": "Sunshine XC 1",
+    "minutes": {}
+  },
+  "919": {
+    "completed": false,
+    "name": "Brewer's Byway Extension 1",
+    "minutes": {}
+  },
+  "920": {
+    "completed": false,
+    "name": "Polecat Loop 4",
+    "minutes": {}
+  },
+  "921": {
+    "completed": false,
+    "name": "Polecat Loop 1",
+    "minutes": {}
+  },
+  "922": {
+    "completed": false,
+    "name": "Polecat Loop 3",
+    "minutes": {}
+  },
+  "923": {
+    "completed": false,
+    "name": "Polecat Loop 5",
+    "minutes": {}
+  },
+  "924": {
+    "completed": false,
+    "name": "Polecat Loop 2",
+    "minutes": {}
+  },
+  "925": {
+    "completed": false,
+    "name": "Polecat Loop 6",
+    "minutes": {}
+  },
+  "926": {
+    "completed": false,
+    "name": "Polecat Loop 7",
+    "minutes": {}
+  },
+  "927": {
+    "completed": false,
+    "name": "Brewers Byway 2",
+    "minutes": {}
+  },
+  "928": {
+    "completed": false,
+    "name": "Spring Creek 2",
+    "minutes": {}
+  },
+  "929": {
+    "completed": false,
+    "name": "Harlow's Hollows 4",
+    "minutes": {}
+  },
+  "930": {
+    "completed": false,
+    "name": "Harlow's Hollows 3",
+    "minutes": {}
+  },
+  "931": {
+    "completed": false,
+    "name": "Harlow's Hollows Connector 1",
+    "minutes": {}
+  },
+  "932": {
+    "completed": false,
+    "name": "Harlow's Hollows 1",
+    "minutes": {}
+  },
+  "933": {
+    "completed": false,
+    "name": "Harlow's Hollows 2",
+    "minutes": {}
+  },
+  "934": {
+    "completed": false,
+    "name": "Cartwright Connector 1",
+    "minutes": {}
+  },
+  "935": {
+    "completed": false,
+    "name": "Femrite's Patrol 3",
+    "minutes": {}
+  },
+  "936": {
+    "completed": false,
+    "name": "Curlew Connection 2",
+    "minutes": {}
+  },
+  "937": {
+    "completed": false,
+    "name": "Curlew Connection 1",
+    "minutes": {}
+  },
+  "938": {
+    "completed": false,
+    "name": "Mores Mountain 1",
+    "minutes": {}
+  },
+  "1182": {
+    "completed": false,
+    "name": "Buena Vista Trail 4",
+    "minutes": {}
+  },
+  "1183": {
+    "completed": false,
+    "name": "Ridge Crest 5",
+    "minutes": {}
+  },
+  "1184": {
+    "completed": false,
+    "name": "Rock Garden 2",
+    "minutes": {}
+  },
+  "1185": {
+    "completed": false,
+    "name": "Who Now Loop Trail 4",
+    "minutes": {}
+  },
+  "1186": {
+    "completed": false,
+    "name": "Harrison Hollow 1",
+    "minutes": {}
+  },
+  "1187": {
+    "completed": false,
+    "name": "Harrison Hollow 2",
+    "minutes": {}
+  },
+  "1188": {
+    "completed": false,
+    "name": "Harrison Ridge 1",
+    "minutes": {}
+  },
+  "1189": {
+    "completed": false,
+    "name": "Harrison Ridge 2",
+    "minutes": {}
+  },
+  "1190": {
+    "completed": false,
+    "name": "Bob Smylie 1",
+    "minutes": {}
+  },
+  "1191": {
+    "completed": false,
+    "name": "Bob Smylie 2",
+    "minutes": {}
+  },
+  "1192": {
+    "completed": false,
+    "name": "Rock Garden 3",
+    "minutes": {}
+  },
+  "1193": {
+    "completed": false,
+    "name": "Table Rock Quarry Trail 3",
+    "minutes": {}
+  },
+  "1194": {
+    "completed": false,
+    "name": "Ridge Crest 3",
+    "minutes": {}
+  },
+  "1195": {
+    "completed": false,
+    "name": "Ridge Crest 4",
+    "minutes": {}
+  },
+  "1196": {
+    "completed": false,
+    "name": "Central Ridge Trail 4",
+    "minutes": {}
+  },
+  "1197": {
+    "completed": false,
+    "name": "Central Ridge Trail 5",
+    "minutes": {}
+  },
+  "1198": {
+    "completed": false,
+    "name": "Central Ridge Trail 6",
+    "minutes": {}
+  },
+  "1199": {
+    "completed": false,
+    "name": "Central Ridge Spur 2",
+    "minutes": {}
+  },
+  "1200": {
+    "completed": false,
+    "name": "Central Ridge Spur 3",
+    "minutes": {}
+  },
+  "1201": {
+    "completed": false,
+    "name": "Central Ridge Spur 4",
+    "minutes": {}
+  },
+  "1202": {
+    "completed": false,
+    "name": "Access Trail CR 1",
+    "minutes": {}
+  },
+  "1203": {
+    "completed": false,
+    "name": "Central Ridge Spur 1",
+    "minutes": {}
+  },
+  "1204": {
+    "completed": false,
+    "name": "Ridge Rd 1",
+    "minutes": {}
+  },
+  "1205": {
+    "completed": false,
+    "name": "Lodge Trail 1",
+    "minutes": {}
+  },
+  "1206": {
+    "completed": false,
+    "name": "Around the Mountain Trail 6",
+    "minutes": {}
+  }
 }

--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -223,23 +223,37 @@ def load_segment_tracking(track_path: str, segments_path: str) -> Dict[str, bool
     """Return a mapping of segment IDs to completion status.
 
     If ``track_path`` does not exist, a file is created containing all
-    segment IDs from ``segments_path`` marked as incomplete. The resulting
-    dictionary is always returned so that calling code can determine which
-    segments are considered finished.
+    segment IDs from ``segments_path`` marked as incomplete. The tracking file
+    stores additional metadata but this function only returns the completion
+    status for use by the planner.
     """
 
     if os.path.exists(track_path):
         with open(track_path) as f:
             data = json.load(f)
         if isinstance(data, dict):
-            return {str(k): bool(v) for k, v in data.items()}
+            result = {}
+            for k, v in data.items():
+                if isinstance(v, bool):
+                    result[str(k)] = bool(v)
+                elif isinstance(v, dict):
+                    result[str(k)] = bool(v.get("completed", False))
+                else:
+                    raise ValueError(
+                        "segment tracking values must be bool or object"
+                    )
+            return result
         raise ValueError("segment tracking file must be a JSON object")
 
     segments = load_segments(segments_path)
-    tracking = {str(e.seg_id): False for e in segments if e.seg_id is not None}
+    tracking = {
+        str(e.seg_id): {"completed": False, "name": e.name, "minutes": {}}
+        for e in segments
+        if e.seg_id is not None
+    }
     with open(track_path, "w") as f:
         json.dump(tracking, f, indent=2)
-    return tracking
+    return {sid: False for sid in tracking}
 
 
 def search_loops(


### PR DESCRIPTION
## Summary
- extend `segment_tracking.json` entries with `name` and per-year `minutes`
- auto-populate names when file is first created
- update README to describe new format
- update `load_segment_tracking` to support old and new schemas

## Testing
- `pip install pandas gpxpy shapely rtree networkx scikit-learn rasterio numpy elevation tqdm`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499f178d908329a82ed3a74e1ccb0f