### PR TITLE
Add HTML plan output

### DIFF
--- a/requirements.toml
+++ b/requirements.toml
@@ -14,4 +14,5 @@ dependencies = [
   , "tiktoken"
   , "openai"
   , "pyyaml"
+  , "matplotlib"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ tqdm
 tiktoken
 openai
 pyyaml
+matplotlib

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -94,6 +94,8 @@ def test_planner_outputs(tmp_path):
 
     rows = list(csv.DictReader(open(out_csv)))
     assert rows
+    html_out = out_csv.with_suffix(".html")
+    assert html_out.exists()
     for row in rows:
         assert float(row["total_activity_time_min"]) <= 30.0
         day_str = row["date"].replace("-", "")


### PR DESCRIPTION
## Summary
- expand planner utils with route plotting helpers
- generate mobile-friendly daily plan HTML with maps and elevation plots
- embed rationale notes based on schedule budget in CSV and HTML
- export HTML alongside CSV and GPX
- require matplotlib

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a0c9389e08329bbf47defdfb4bd0a