### PR TITLE
Implement infeasible plan detection

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -1011,6 +1011,29 @@ def main(argv=None):
         args.road_threshold,
     )
 
+    # After smoothing, ensure all segments have been scheduled. If any
+    # clusters remain unscheduled the plan is infeasible.
+    if unplanned_macro_clusters:
+        remaining_ids: Set[str] = set()
+        for cluster in unplanned_macro_clusters:
+            for seg in cluster.edges:
+                if seg.seg_id is not None:
+                    remaining_ids.add(str(seg.seg_id))
+
+        avg_hours = (
+            sum(daily_budget_minutes.values()) / len(daily_budget_minutes) / 60.0
+            if daily_budget_minutes
+            else 0.0
+        )
+        msg = (
+            f"With {avg_hours:.1f} hours/day from {start_date} to {end_date}, "
+            "it's impossible to complete all trails. Extend the timeframe or "
+            "increase daily budget."
+        )
+        if remaining_ids:
+            msg += " Unscheduled segment IDs: " + ", ".join(sorted(remaining_ids))
+        parser.error(msg)
+
     # Placeholder for checking daily_plans structure
 
     summary_rows = []

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -407,3 +407,41 @@ def test_balance_workload(tmp_path):
     rows = list(csv.DictReader(open(out_csv)))
     assert any(float(r["total_activity_time_min"]) > 0 for r in rows)
 
+
+def test_infeasible_plan_detection(tmp_path):
+    edges = build_edges(2)
+    seg_path = tmp_path / "segments.json"
+    perf_path = tmp_path / "perf.csv"
+    dem_path = tmp_path / "dem.tif"
+    out_csv = tmp_path / "out.csv"
+    gpx_dir = tmp_path / "gpx"
+    perf_path.write_text("seg_id,year\n")
+    write_segments(seg_path, edges)
+    create_dem(dem_path)
+
+    with pytest.raises(SystemExit):
+        challenge_planner.main(
+            [
+                "--start-date",
+                "2024-07-01",
+                "--end-date",
+                "2024-07-01",
+                "--time",
+                "10",
+                "--pace",
+                "10",
+                "--segments",
+                str(seg_path),
+                "--dem",
+                str(dem_path),
+                "--perf",
+                str(perf_path),
+                "--year",
+                "2024",
+                "--output",
+                str(out_csv),
+                "--gpx-dir",
+                str(gpx_dir),
+            ]
+        )
+


### PR DESCRIPTION
## Summary
- check for unscheduled segments after smoothing the plan
- raise an error if any remain, including unscheduled segment IDs
- test that planner exits when the schedule cannot cover all segments

## Testing
- `pip install -r requirements.txt` *(fails: Installing build dependencies canceled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a0e5e24d48329bcecc2e9229eea2c