### PR TITLE
Set road transition marking default and improve start selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Passing `--roads` allows the planner to use short road connectors. Use
 `--max-road` to limit the mileage of any road link (default 1 mile) and
 `--road-threshold` to control how much faster a road must be compared to the
 all-trail option before it is chosen (default 0.1 for 10% faster).
-Use `--mark-road-transitions` if you would like GPX output to highlight road
-sections with waypoints and track segment metadata.
+Road sections are highlighted in GPX output with waypoints and track segment
+metadata by default.
 
 Pass `--daily-hours-file` with a JSON mapping of dates to available hours if
 your schedule varies day to day. Any date not listed in the file defaults to

--- a/TODO.md
+++ b/TODO.md
@@ -29,10 +29,9 @@ This list tracks potential future enhancements and areas for improvement for the
 
 6.  **Visual Distinction of Road Connectors in GPX:**
     *   The user story suggests marking road connectors distinctly in GPX files.
-    *   Implemented via the ``--mark-road-transitions`` flag. When enabled, GPX files
-        contain separate track segments labelled ``trail`` or ``road`` and include
-        waypoints at the start and end of each road connector for compatibility with
-        basic GPX viewers.
+    *   GPX output now highlights road sections by default. Separate track segments are
+        labelled ``trail`` or ``road`` and waypoints are inserted at the start and end
+        of each road connector for compatibility with basic GPX viewers.
 
 ## Data & Performance
 

--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -382,7 +382,7 @@ def search_loops(
     return best
 
 
-def _segments_from_edges(edges: List[Edge], mark_road_transitions: bool = False):
+def _segments_from_edges(edges: List[Edge], mark_road_transitions: bool = True):
     """Convert a sequence of edges into GPX track segments and waypoints."""
     import gpxpy.gpx
     import xml.etree.ElementTree as ET
@@ -478,7 +478,7 @@ def _segments_from_edges(edges: List[Edge], mark_road_transitions: bool = False)
 def write_gpx(
     path: str,
     edges: List[Edge],
-    mark_road_transitions: bool = False,
+    mark_road_transitions: bool = True,
     start_name: Optional[str] = None,
 ):
     """Write a GPX file for the given sequence of edges.
@@ -520,7 +520,7 @@ def write_gpx(
 def write_multiday_gpx(
     path: str,
     daily_plans: List[Dict[str, Any]],
-    mark_road_transitions: bool = False,
+    mark_road_transitions: bool = True,
     colors: Optional[List[str]] = None,
 ):
     """Write a GPX file containing tracks for all days in ``daily_plans``.


### PR DESCRIPTION
## Summary
- highlight road sections in GPX by default
- add option to disable road markers
- pick segment starts near roads when no trailhead is found
- avoid aborting when routes are infeasible
- adjust tests for updated behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1d1ba0f083298555bcbe75496c9f