### PR TITLE
Update default daily hours to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ are written for navigation.
 
 ```bash
 python -m trail_route_ai.challenge_planner --start-date 2024-07-01 --end-date 2024-07-31 \
-    --time 3h --pace 10 --grade 30 --year 2024 \
+    --time 4h --pace 10 --grade 30 --year 2024 \
     --dem data/srtm_boise_clipped.tif
 ```
 
@@ -82,7 +82,7 @@ metadata by default.
 
 Pass `--daily-hours-file` with a JSON mapping of dates to available hours if
 your schedule varies day to day. Any date not listed in the file defaults to
-3 hours of running time.
+4 hours of running time.
 
 When multiple candidate activities are otherwise equally convenient,
 the planner favors clusters that are more geographically isolated. Clearing
@@ -97,7 +97,7 @@ Example with custom output locations:
 
 ```bash
 python -m trail_route_ai.challenge_planner --start-date 2024-07-01 --end-date 2024-07-31 \
-    --time 3h --pace 10 --grade 30 --year 2024 \
+    --time 4h --pace 10 --grade 30 --year 2024 \
     --output plans/challenge.csv --gpx-dir plans/gpx
 ```
 
@@ -112,7 +112,7 @@ default for per-day time budgets if present:
 ```yaml
 start_date: "2024-07-01"
 end_date: "2024-07-31"
-time: "3h"
+time: "4h"
 pace: 10
 grade: 30
 gpx_dir: "plans/gpx"
@@ -123,7 +123,7 @@ daily_hours_file: "config/daily_hours.json"
 Pass `--config path/to/file.yaml` to load a different configuration file.
 
 The optional `config/daily_hours.json` file should map ISO dates to the hours
-available for running on that date. Any date not listed defaults to 3 hours.
+available for running on that date. Any date not listed defaults to 4 hours.
 Example:
 
 ```json

--- a/config/planner_config.json
+++ b/config/planner_config.json
@@ -1,7 +1,7 @@
 {
   "start_date": "2025-06-19",
   "end_date": "2025-07-18",
-  "time": "3h",
+  "time": "4h",
   "pace": 10,
   "grade": 30,
   "gpx_dir": "gpx",

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -36,7 +36,7 @@ class ClusterInfo:
 class PlannerConfig:
     start_date: Optional[str] = None
     end_date: Optional[str] = None
-    time: str = "3h"
+    time: str = "4h"
     daily_hours_file: Optional[str] = None
     pace: Optional[float] = None
     grade: float = 0.0
@@ -390,7 +390,7 @@ def smooth_daily_plans(
         return
 
     def remaining_time(day_plan: Dict[str, object]) -> float:
-        budget = daily_budget_minutes.get(day_plan["date"], 180.0)
+        budget = daily_budget_minutes.get(day_plan["date"], 240.0)
         used = day_plan["total_activity_time"] + day_plan["total_drive_time"]
         return budget - used
 
@@ -651,7 +651,7 @@ def main(argv=None):
     parser.add_argument("--end-date", required="end_date" not in config_defaults, help="Challenge end date YYYY-MM-DD")
     parser.add_argument(
         "--time",
-        default=config_defaults.get("time", "3h"),
+        default=config_defaults.get("time", "4h"),
         help="Default daily time budget when --daily-hours-file is not provided"
     )
     parser.add_argument(
@@ -729,7 +729,7 @@ def main(argv=None):
                 hours = 0
             user_hours[d] = hours
 
-    default_daily_minutes = 180.0 if daily_hours_file else budget
+    default_daily_minutes = 240.0 if daily_hours_file else budget
     for i in range(num_days):
         day = start_date + datetime.timedelta(days=i)
         hours = user_hours.get(day, default_daily_minutes / 60.0)


### PR DESCRIPTION
## Summary
- bump default time budget from 3h to 4h
- update sample planner config and docs
- adjust planner code for new 4h default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a2b8c81608329a9d8db91bbecdf3f