### PR TITLE
Add redundancy metrics to plan output

### DIFF
--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -115,6 +115,9 @@ def test_planner_outputs(tmp_path):
         assert len(pts) >= 2
         assert "plan_description" in row and row["plan_description"]
         assert "route_description" in row and row["route_description"]
+        assert "unique_trail_miles" in row
+        assert "redundant_miles" in row
+        assert "redundant_pct" in row
         assert float(row["total_trail_elev_gain_ft"]) > 0
         assert "notes" in row
 
@@ -166,6 +169,7 @@ def test_completed_excluded(tmp_path):
     assert "S1" not in text
     assert "S1" not in text2
     for row in rows:
+        assert "unique_trail_miles" in row
         assert "notes" in row
 
 


### PR DESCRIPTION
## Summary
- calculate unique trail mileage and redundancy in challenge planner
- output new metrics in CSV summary
- ensure fallback routing respects daily budget and add tests for metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3401b91c8329910531adc41d342b