### PR TITLE
Improve nearest node performance using KDTree

### DIFF
--- a/tests/test_nearest_node.py
+++ b/tests/test_nearest_node.py
@@ -1,0 +1,14 @@
+import pytest
+
+from trail_route_ai import challenge_planner
+
+
+def test_nearest_node_kdtree_matches_linear(monkeypatch):
+    pytest.importorskip("scipy")
+    nodes = [(float(i), float(i % 2)) for i in range(100)]
+    pt = (42.3, 0.4)
+    tree = challenge_planner.build_kdtree(nodes)
+    kd_res = challenge_planner.nearest_node(tree, pt)
+    monkeypatch.setattr(challenge_planner, "_HAVE_SCIPY", False)
+    lin_res = challenge_planner.nearest_node(nodes, pt)
+    assert kd_res == lin_res


### PR DESCRIPTION
## Summary
- optimize node lookup with `scipy.spatial.cKDTree`
- cache KDTree in `ClusterInfo`
- update planner logic to use KDTree indices
- add unit test covering KDTree behaviour

## Testing
- `pip install -r requirements.txt` *(fails: building wheel for pyrosm cancelled)*
- `pytest tests/test_nearest_node.py -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_684a48a187e08329ac903730d09271bf