### PR TITLE
Add optional path cache for planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ a configuration file using the same names:
 - `--average-driving-speed-mph FLOAT` – assumed driving speed (default `30`)
 - `--max-drive-minutes-per-transfer FLOAT` – limit drive time between clusters
 - `--review` – send the final plan for AI review
+- `--precompute-paths` – cache shortest paths between all graph nodes (uses more memory)
+
+Enabling `--precompute-paths` may greatly reduce the number of Dijkstra searches
+during planning, but the cache grows with the square of the number of graph
+nodes and can consume significant RAM on large datasets.
 
 ## Road connectors
 

--- a/tests/test_plan_route_greedy.py
+++ b/tests/test_plan_route_greedy.py
@@ -112,7 +112,7 @@ def old_plan_route_greedy(G, edges, start, pace, grade, road_pace, max_road, roa
 def test_greedy_respects_max_road():
     G, trails = build_test_graph()
     params = dict(pace=10.0, grade=0.0, road_pace=15.0, max_road=1.0, road_threshold=0.1)
-    route, order = challenge_planner._plan_route_greedy(G, trails, (0.0, 0.0), **params)
+    route, order = challenge_planner._plan_route_greedy(G, trails, (0.0, 0.0), **params, dist_cache=None)
 
     # The two trail segments require a 2-mile road connector which exceeds
     # ``max_road``. The greedy planner should therefore fail to produce a route.


### PR DESCRIPTION
## Summary
- add `--precompute-paths` flag
- optionally precompute dijkstra paths for all graph nodes
- use cached paths in planner routines
- document memory trade-offs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a523b6e508329bdcc522041a541d4