### PR TITLE
Fix time parser

### DIFF
--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import List, Dict, Tuple, Set, Optional, Any
 import networkx as nx
+import re
 
 
 @dataclass
@@ -638,6 +639,12 @@ def parse_time_budget(value: str) -> float:
     """
 
     text = value.strip().lower()
+    # Formats like "1h30" or "2h15m"
+    m = re.match(r"^(\d+(?:\.\d+)?)h(?:([0-5]?\d)(?:m)?)?$", text)
+    if m:
+        hours = float(m.group(1))
+        minutes = float(m.group(2) or 0)
+        return hours * 60.0 + minutes
     if text.endswith("h"):
         return float(text[:-1]) * 60.0
     if ":" in text:

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,11 @@
+import pytest
+from trail_route_ai import planner_utils
+
+def test_parse_time_budget_hours_minutes():
+    assert planner_utils.parse_time_budget('1h30') == pytest.approx(90.0)
+    assert planner_utils.parse_time_budget('2h15m') == pytest.approx(135.0)
+
+def test_parse_time_budget_formats():
+    assert planner_utils.parse_time_budget('1:45') == pytest.approx(105.0)
+    assert planner_utils.parse_time_budget('90') == pytest.approx(90.0)
+    assert planner_utils.parse_time_budget('1.5h') == pytest.approx(90.0)


### PR DESCRIPTION
## Summary
- handle hour-minute formats like `1h30` in `parse_time_budget`
- add tests for time parsing edge cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5551b01483298dcae778e74fa93d