### PR TITLE
Fix README grammar and test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Boise Trails Challenge AI Assistant
 
-*An automated route planner to help me plan my route for trail segment in the Boise Trails Challenge.*
+*An automated route planner to help me plan my route for trail segments in the Boise Trails Challenge.*
 
 The [Boise Trails Challenge](https://boisetrailschallenge.com) is a month-long event where participants attempt to cover **every official trail segment** in the Boise area within a defined period. 
 
@@ -64,10 +64,11 @@ This currently downloads the latest OpenStreetMap data for Idaho (`idaho-latest.
 
 ## Running Tests
 
-If you want to run the test suite (for development purposes), install the additional dev/test requirements and run `pytest`:
+If you want to run the test suite (for development purposes), install the runtime dependencies and `pytest`:
 
 ```bash
-pip install -r requirements.txt  # (ensure optional test libraries are installed)
+pip install -r requirements.txt
+pip install pytest
 pytest -q
 ```
 


### PR DESCRIPTION
## Summary
- clarify README introduction
- correct instructions for running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684ad51d684c8329968a5676c7658e20