### PR TITLE
Add CPU profiling example

### DIFF
--- a/profile_challenge_planner.py
+++ b/profile_challenge_planner.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+from trail_route_ai import challenge_planner, planner_utils
+
+def create_dem(path: Path) -> None:
+    data = np.tile(np.arange(4, dtype=np.float32) * 10, (2, 1))
+    transform = from_origin(0, 1, 1, 1)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(data, 1)
+
+def build_edges(n: int = 30):
+    edges = []
+    for i in range(n):
+        start = (float(i), 0.0)
+        end = (float(i) + 1.0, 0.0)
+        seg_id = f"S{i}"
+        edges.append(
+            planner_utils.Edge(seg_id, seg_id, start, end, 1.0, 0.0, [start, end], "trail", "both")
+        )
+    return edges
+
+def main() -> None:
+    tmp = Path("prof_tmp")
+    tmp.mkdir(exist_ok=True)
+    seg_path = tmp / "segments.json"
+    perf_path = tmp / "perf.csv"
+    dem_path = tmp / "dem.tif"
+    out_csv = tmp / "out.csv"
+    gpx_dir = tmp / "gpx"
+    edges = build_edges()
+    perf_path.write_text("seg_id,year\n")
+    data = {
+        "segments": [
+            {"id": e.seg_id, "name": e.name, "coordinates": e.coords, "LengthFt": 5280}
+            for e in edges
+        ]
+    }
+    with open(seg_path, "w") as f:
+        json.dump(data, f)
+    create_dem(dem_path)
+    challenge_planner.main(
+        [
+            "--start-date",
+            "2024-07-01",
+            "--end-date",
+            "2024-07-03",
+            "--time",
+            "30",
+            "--pace",
+            "10",
+            "--segments",
+            str(seg_path),
+            "--dem",
+            str(dem_path),
+            "--perf",
+            str(perf_path),
+            "--year",
+            "2024",
+            "--output",
+            str(out_csv),
+            "--gpx-dir",
+            str(gpx_dir),
+        ]
+    )
+
+if __name__ == "__main__":
+    main()

--- a/profile_summary.txt
+++ b/profile_summary.txt
@@ -1,0 +1,20 @@
+Thu Jun 12 13:53:59 2025    profile.out
+
+         4041974 function calls (3957399 primitive calls) in 5.793 seconds
+
+   Ordered by: cumulative time
+   List reduced from 11866 to 10 due to restriction <10>
+
+   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
+    468/8    0.028    0.000    6.828    0.854 /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/matplotlib/text.py:358(_get_layout)
+   988/17    0.006    0.000    6.776    0.399 /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/matplotlib/text.py:65(_get_text_metrics_with_cache)
+  2617/16    0.023    0.000    4.077    0.255 <frozen importlib._bootstrap>:1349(_find_and_load)
+  2579/16    0.016    0.000    4.076    0.255 <frozen importlib._bootstrap>:1304(_find_and_load_unlocked)
+  2503/15    0.012    0.000    4.071    0.271 <frozen importlib._bootstrap>:911(_load_unlocked)
+  2233/14    0.008    0.000    4.070    0.291 <frozen importlib._bootstrap_external>:993(exec_module)
+  5808/26    0.007    0.000    4.067    0.156 <frozen importlib._bootstrap>:480(_call_with_frames_removed)
+   825/33    0.002    0.000    3.816    0.116 {built-in method builtins.__import__}
+ 2463/125    0.007    0.000    3.810    0.030 <frozen importlib._bootstrap>:1390(_handle_fromlist)
+     32/5    0.001    0.000    3.762    0.752 /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/matplotlib/text.py:73(_get_text_metrics_with_cache_impl)
+
+


### PR DESCRIPTION
## Summary
- add `profile_challenge_planner.py` to run a small planner workload
- include `profile_summary.txt` showing top functions by cumulative time

## Testing
- `python profile_challenge_planner.py`
- `PYTHONPATH=src python -m cProfile -o profile.out profile_challenge_planner.py`


------
https://chatgpt.com/codex/tasks/task_e_684ad7801cd4832997d96d20eace68b7