### PR TITLE
Add output directory support

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -83,6 +83,8 @@ class PlannerConfig:
     remaining: Optional[str] = None
     output: str = "challenge_plan.csv"
     gpx_dir: str = "gpx"
+    output_dir: Optional[str] = None
+    auto_output_dir: bool = False
     mark_road_transitions: bool = True
     average_driving_speed_mph: float = 30.0
     max_drive_minutes_per_transfer: float = 30.0
@@ -1485,6 +1487,17 @@ def main(argv=None):
         help="Directory for GPX output",
     )
     parser.add_argument(
+        "--output-dir",
+        default=config_defaults.get("output_dir"),
+        help="Directory to store all outputs for this run",
+    )
+    parser.add_argument(
+        "--auto-output-dir",
+        action="store_true",
+        default=config_defaults.get("auto_output_dir", False),
+        help="Automatically create dated output directory when --output-dir is not given",
+    )
+    parser.add_argument(
         "--no-mark-road-transitions",
         dest="mark_road_transitions",
         action="store_false",
@@ -1527,6 +1540,16 @@ def main(argv=None):
 
     if "--time" in argv and "--daily-hours-file" not in argv:
         args.daily_hours_file = None
+
+    output_dir = args.output_dir
+    if output_dir is None and args.auto_output_dir:
+        today = datetime.date.today().isoformat()
+        output_dir = os.path.join("outputs", f"plan_{today}")
+        args.output_dir = output_dir
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        args.output = os.path.join(output_dir, os.path.basename(args.output))
+        args.gpx_dir = os.path.join(output_dir, os.path.basename(args.gpx_dir))
 
     home_coord = None
     if args.home_lat is not None and args.home_lon is not None:

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -556,3 +556,45 @@ def test_unrouteable_cluster_split(tmp_path):
     assert int(day["num_activities"]) == 2
     assert int(day["num_drives"]) == 1
 
+
+def test_output_directory(tmp_path):
+    edges = build_edges(2)
+    seg_path = tmp_path / "segments.json"
+    perf_path = tmp_path / "perf.csv"
+    dem_path = tmp_path / "dem.tif"
+    output_dir = tmp_path / "outputs"
+    perf_path.write_text("seg_id,year\n")
+    write_segments(seg_path, edges)
+    create_dem(dem_path)
+
+    challenge_planner.main(
+        [
+            "--start-date",
+            "2024-07-01",
+            "--end-date",
+            "2024-07-01",
+            "--time",
+            "60",
+            "--pace",
+            "10",
+            "--segments",
+            str(seg_path),
+            "--dem",
+            str(dem_path),
+            "--perf",
+            str(perf_path),
+            "--year",
+            "2024",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    csv_path = output_dir / "challenge_plan.csv"
+    html_path = output_dir / "challenge_plan.html"
+    gpx_dir = output_dir / "gpx"
+    assert csv_path.exists()
+    assert html_path.exists()
+    assert gpx_dir.is_dir()
+    assert any(gpx_dir.glob("*.gpx"))
+


### PR DESCRIPTION
## Summary
- add optional `--output-dir` and `--auto-output-dir` flags to store outputs in a custom folder
- create directory and adjust CSV/GPX paths when provided
- add regression test for output directory handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aefae9e6c83299023f67fff3b0da8