### PR TITLE
Add quick hit list export

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -820,8 +820,13 @@ def write_plan_html(
     daily_plans: List[Dict[str, object]],
     image_dir: str,
     dem_path: Optional[str] = None,
+    hit_list: Optional[List[Dict[str, object]]] = None,
 ) -> None:
-    """Write an HTML overview of ``daily_plans`` with maps and elevation."""
+    """Write an HTML overview of ``daily_plans`` with maps and elevation.
+
+    When ``hit_list`` is provided, an additional section summarizing quick
+    segments is appended to the report.
+    """
 
     os.makedirs(image_dir, exist_ok=True)
 
@@ -954,6 +959,19 @@ def write_plan_html(
     lines.append(f"<li>Total Time: {totals['total_time_min']:.0f} min</li>")
     lines.append("</ul>")
 
+    if hit_list:
+        lines.append("<h2>Hit List: Quick Segments</h2>")
+        lines.append("<ul>")
+        for item in hit_list:
+            name = item.get("name", "Trail")
+            dist = item.get("distance_mi", 0.0)
+            gain = item.get("elev_gain_ft", 0.0)
+            t = item.get("time_min", 0.0)
+            lines.append(
+                f"<li><b>{name}</b> – {dist:.1f} mi, {gain:.0f} ft (est. {t:.0f} min)</li>"
+            )
+        lines.append("</ul>")
+
     lines.append("</body></html>")
 
     with open(path, "w") as f:
@@ -967,11 +985,14 @@ def export_plan_files(
     csv_path: Optional[str] = None,
     write_gpx: bool = True,
     review: Optional[bool] = None,
+    hit_list: Optional[List[Dict[str, object]]] = None,
 ) -> None:
     """Write CSV and HTML outputs for ``daily_plans``.
 
     ``csv_path`` overrides ``args.output``. GPX files and plan review are
     skipped when ``write_gpx`` is ``False`` or ``review`` is ``False``.
+    When ``hit_list`` is provided, a ``hit_list.csv`` file is written and the
+    items are included in the HTML report.
     """
 
     orig_output = args.output
@@ -1276,6 +1297,24 @@ def export_plan_files(
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(summary_rows)
+        if hit_list is not None:
+            hit_path = os.path.join(
+                os.path.dirname(args.output),
+                "hit_list.csv",
+            )
+            with open(hit_path, "w", newline="") as hf:
+                hw = csv.DictWriter(
+                    hf,
+                    fieldnames=[
+                        "name",
+                        "segments",
+                        "distance_mi",
+                        "elev_gain_ft",
+                        "time_min",
+                    ],
+                )
+                hw.writeheader()
+                hw.writerows(hit_list)
     else:
         default_fieldnames = [
             "date",
@@ -1298,6 +1337,24 @@ def export_plan_files(
         with open(args.output, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=default_fieldnames)
             writer.writeheader()
+        if hit_list is not None:
+            hit_path = os.path.join(
+                os.path.dirname(args.output),
+                "hit_list.csv",
+            )
+            with open(hit_path, "w", newline="") as hf:
+                hw = csv.DictWriter(
+                    hf,
+                    fieldnames=[
+                        "name",
+                        "segments",
+                        "distance_mi",
+                        "elev_gain_ft",
+                        "time_min",
+                    ],
+                )
+                hw.writeheader()
+                hw.writerows(hit_list)
 
     if args.review and summary_rows:
         plan_text = "\n".join(
@@ -1332,7 +1389,13 @@ def export_plan_files(
     html_out = os.path.splitext(args.output)[0] + ".html"
     img_dir = os.path.join(os.path.dirname(html_out), "plan_images")
 
-    write_plan_html(html_out, daily_plans, img_dir, dem_path=args.dem)
+    write_plan_html(
+        html_out,
+        daily_plans,
+        img_dir,
+        dem_path=args.dem,
+        hit_list=hit_list,
+    )
     print(f"HTML plan written to {html_out}")
 
     print(f"Challenge plan written to {args.output}")
@@ -1640,6 +1703,13 @@ def main(argv=None):
     current_challenge_segments = [
         e for e in all_trail_segments if str(e.seg_id) in current_challenge_segment_ids
     ]
+
+    quick_hits = planner_utils.identify_quick_hits(
+        current_challenge_segments,
+        args.pace,
+        args.grade,
+        args.road_pace,
+    )
 
     # nodes list might be useful later for starting points, keep it around
     # nodes = list({e.start for e in on_foot_routing_graph_edges} | {e.end for e in on_foot_routing_graph_edges})
@@ -2077,7 +2147,14 @@ def main(argv=None):
 
         if args.draft_every and args.draft_every > 0 and (day_idx + 1) % args.draft_every == 0:
             draft_csv = os.path.splitext(args.output)[0] + f"_draft_{day_idx+1}.csv"
-            export_plan_files(daily_plans, args, csv_path=draft_csv, write_gpx=False, review=False)
+            export_plan_files(
+                daily_plans,
+                args,
+                csv_path=draft_csv,
+                write_gpx=False,
+                review=False,
+                hit_list=quick_hits,
+            )
 
     # Smooth the schedule if we have lightly used days and remaining clusters
     smooth_daily_plans(
@@ -2116,7 +2193,7 @@ def main(argv=None):
             msg += " Unscheduled segment IDs: " + ", ".join(sorted(remaining_ids))
         tqdm.write(msg, file=sys.stderr)
 
-    export_plan_files(daily_plans, args)
+    export_plan_files(daily_plans, args, hit_list=quick_hits)
 
 
 if __name__ == "__main__":

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -100,6 +100,8 @@ def test_planner_outputs(tmp_path):
     assert rows
     html_out = out_csv.with_suffix(".html")
     assert html_out.exists()
+    hit_csv = out_csv.with_name("hit_list.csv")
+    assert hit_csv.exists()
     for row in rows:
         if row["date"] == "Totals":
             continue

--- a/tests/test_planner_utils_extra.py
+++ b/tests/test_planner_utils_extra.py
@@ -73,3 +73,16 @@ def test_estimate_drive_time_minutes():
     G.add_edge((0.0, 0.0), (1.0, 0.0), length_mi=1.0)
     t = planner_utils.estimate_drive_time_minutes((0.0, 0.0), (1.0, 0.0), G, 30.0)
     assert pytest.approx(2.0) == t
+
+
+def test_identify_quick_hits():
+    segs = [
+        planner_utils.Edge("A", "A", (0.0, 0.0), (0.5, 0.0), 0.5, 0.0, [(0.0, 0.0), (0.5, 0.0)]),
+        planner_utils.Edge("B", "B", (1.0, 0.0), (1.5, 0.0), 0.5, 0.0, [(1.0, 0.0), (1.5, 0.0)]),
+        planner_utils.Edge("C", "C", (5.0, 5.0), (5.5, 5.0), 0.5, 0.0, [(5.0, 5.0), (5.5, 5.0)]),
+    ]
+
+    hits = planner_utils.identify_quick_hits(segs, pace=10.0, grade=0.0, road_pace=18.0)
+    assert len(hits) >= 2
+    names = [h["name"] for h in hits]
+    assert any("A" in n for n in names)


### PR DESCRIPTION
## Summary
- implement `identify_quick_hits` in planner utils
- support writing hit list CSV and HTML section
- compute quick hit segments in challenge planner
- update tests for new outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684afcb176a08329a228d33bc51eb679