### PR TITLE
Export GPX for draft plans

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -2151,7 +2151,7 @@ def main(argv=None):
                 daily_plans,
                 args,
                 csv_path=draft_csv,
-                write_gpx=False,
+                write_gpx=True,
                 review=False,
                 hit_list=quick_hits,
             )


### PR DESCRIPTION
## Summary
- ensure `--draft-every` exports GPX files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b1320c20883298a063d1ab4f6df7d