### PR TITLE
Improve drive avoidance logic

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -32,6 +32,15 @@ from trail_route_ai import planner_utils, plan_review
 # Type aliases
 Edge = planner_utils.Edge
 
+# Thresholds for when to prefer driving between activities
+DRIVE_FASTER_FACTOR = 2.0  # drive must be at least this many times faster
+MIN_DRIVE_TIME_SAVINGS_MIN = 5.0
+MIN_DRIVE_DISTANCE_MI = 1.0
+# Extra time assumed for each drive (parking, transition, etc.)
+DRIVE_PARKING_OVERHEAD_MIN = 10.0
+# Additional bias toward walking when doing so would complete a segment
+COMPLETE_SEGMENT_BONUS = 1.0
+
 
 def build_kdtree(nodes: List[Tuple[float, float]]):
     """Return a KDTree for ``nodes`` if SciPy is available."""
@@ -76,7 +85,7 @@ class PlannerConfig:
     home_lat: Optional[float] = 43.635278
     home_lon: Optional[float] = -116.205
     max_road: float = 1.0
-    road_threshold: float = 0.1
+    road_threshold: float = 1.0
     road_pace: float = 18.0
     perf: str = "data/segment_perf.csv"
     year: Optional[int] = None
@@ -1521,7 +1530,7 @@ def main(argv=None):
     parser.add_argument(
         "--road-threshold",
         type=float,
-        default=config_defaults.get("road_threshold", 0.1),
+        default=config_defaults.get("road_threshold", 1.0),
         help="Fractional speed advantage required to choose a road connector",
     )
     parser.add_argument(
@@ -1924,6 +1933,7 @@ def main(argv=None):
                             road_graph_for_drive,
                             args.average_driving_speed_mph,
                         )
+                        drive_time_tmp += DRIVE_PARKING_OVERHEAD_MIN
                     if drive_time_tmp < best_drive_time_to_start:
                         best_drive_time_to_start = drive_time_tmp
                         best_start_node = cand_node
@@ -1996,6 +2006,52 @@ def main(argv=None):
                 current_drive_time = best_drive_time_to_start
                 drive_from_coord_for_this_candidate = drive_origin
                 drive_to_coord_for_this_candidate = best_start_node
+
+                if last_activity_end_coord and best_drive_time_to_start < float("inf"):
+                    walk_time = float("inf")
+                    walk_edges: List[Edge] = []
+                    try:
+                        walk_path = nx.shortest_path(
+                            G, drive_origin, best_start_node, weight="weight"
+                        )
+                        walk_edges = edges_from_path(G, walk_path)
+                        walk_time = total_time(
+                            walk_edges, args.pace, args.grade, args.road_pace
+                        )
+                    except (nx.NetworkXNoPath, nx.NodeNotFound):
+                        pass
+
+                    drive_time_tmp, drive_dist_tmp = planner_utils.estimate_drive_time_minutes(
+                        drive_origin,
+                        best_start_node,
+                        road_graph_for_drive,
+                        args.average_driving_speed_mph,
+                        return_distance=True,
+                    )
+                    drive_time_tmp += DRIVE_PARKING_OVERHEAD_MIN
+
+                    walk_completion_time = sum(
+                        planner_utils.estimate_time(e, args.pace, args.grade, args.road_pace)
+                        for e in walk_edges
+                        if e.seg_id is not None
+                        and str(e.seg_id) in current_challenge_segment_ids
+                    )
+                    adjusted_walk = walk_time - walk_completion_time
+                    factor = DRIVE_FASTER_FACTOR + (
+                        COMPLETE_SEGMENT_BONUS if walk_completion_time > 0 else 0.0
+                    )
+
+                    if (
+                        walk_time < float("inf")
+                        and (
+                            adjusted_walk <= drive_time_tmp * factor
+                            or adjusted_walk - drive_time_tmp <= MIN_DRIVE_TIME_SAVINGS_MIN
+                            or drive_dist_tmp <= MIN_DRIVE_DISTANCE_MI
+                        )
+                    ):
+                        route_edges = walk_edges + route_edges
+                        estimated_activity_time += walk_time
+                        current_drive_time = 0.0
 
                 if current_drive_time > args.max_drive_minutes_per_transfer:
                     continue

--- a/tests/test_planner_utils_extra.py
+++ b/tests/test_planner_utils_extra.py
@@ -71,8 +71,11 @@ def test_add_elevation_from_dem(tmp_path):
 def test_estimate_drive_time_minutes():
     G = nx.Graph()
     G.add_edge((0.0, 0.0), (1.0, 0.0), length_mi=1.0)
-    t = planner_utils.estimate_drive_time_minutes((0.0, 0.0), (1.0, 0.0), G, 30.0)
+    t, dist = planner_utils.estimate_drive_time_minutes(
+        (0.0, 0.0), (1.0, 0.0), G, 30.0, return_distance=True
+    )
     assert pytest.approx(2.0) == t
+    assert pytest.approx(1.0) == dist
 
 
 def test_identify_quick_hits():


### PR DESCRIPTION
## Summary
- raise the default road_threshold so walking is chosen unless driving is much faster
- refuse trivial drives: if walking is nearly as quick, append the walk instead
- expose distance info from `estimate_drive_time_minutes`
- update associated unit test
- add drive parking overhead and extra bias toward finishing segments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b148555c08329add07ee0c64b2bf2