### PR TITLE
Implement spur detour logic

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -102,6 +102,8 @@ class PlannerConfig:
     redundancy_threshold: float = 0.2
     allow_connector_trails: bool = True
     rpp_timeout: float = 5.0
+    spur_length_thresh: float = 0.3
+    spur_road_bonus: float = 0.25
 
 
 def load_config(path: str) -> PlannerConfig:
@@ -238,6 +240,9 @@ def _plan_route_greedy(
     max_road: float,
     road_threshold: float,
     dist_cache: Optional[dict] = None,
+    *,
+    spur_length_thresh: float = 0.3,
+    spur_road_bonus: float = 0.25,
 ) -> List[Edge]:
     """Return a continuous route connecting ``edges`` starting from ``start``
     using a greedy nearest-neighbor strategy.
@@ -251,6 +256,11 @@ def _plan_route_greedy(
     route: List[Edge] = []
     order: List[Edge] = []
     cur = start
+    degree: Dict[Tuple[float, float], int] = defaultdict(int)
+    for seg in edges:
+        degree[seg.start] += 1
+        degree[seg.end] += 1
+    last_seg: Optional[Edge] = None
     while remaining:
         paths = None
         if dist_cache and cur in dist_cache:
@@ -275,7 +285,10 @@ def _plan_route_greedy(
                 uses_road = any(ed.kind == "road" for ed in edges_path)
                 candidate_info.append((time, uses_road, e, end, edges_path, road_dist))
 
-        candidates = [c[:5] for c in candidate_info if c[5] <= max_road]
+        allowed_max_road = max_road
+        if last_seg is not None and degree.get(cur, 0) == 1 and last_seg.length_mi <= spur_length_thresh:
+            allowed_max_road += spur_road_bonus
+        candidates = [c[:5] for c in candidate_info if c[5] <= allowed_max_road]
 
         if not candidates:
             if not candidate_info:
@@ -316,6 +329,7 @@ def _plan_route_greedy(
             route.append(e)
             order.append(e)
             cur = e.end
+            last_seg = e
         else:
             # reverse orientation if allowed
             if e.direction != "both":
@@ -335,6 +349,7 @@ def _plan_route_greedy(
             route.append(rev)
             order.append(e)
             cur = rev.end
+            last_seg = e
         remaining.remove(e)
 
     if cur == start:
@@ -391,11 +406,19 @@ def _plan_route_for_sequence(
     max_road: float,
     road_threshold: float,
     dist_cache: Optional[dict] = None,
+    *,
+    spur_length_thresh: float = 0.3,
+    spur_road_bonus: float = 0.25,
 ) -> List[Edge]:
     """Plan a route following ``sequence`` of segments in the given order."""
 
     cur = start
     route: List[Edge] = []
+    degree: Dict[Tuple[float, float], int] = defaultdict(int)
+    for seg in sequence:
+        degree[seg.start] += 1
+        degree[seg.end] += 1
+    last_seg: Optional[Edge] = None
     for seg in sequence:
         candidates = []
         for end in [seg.start, seg.end]:
@@ -408,7 +431,10 @@ def _plan_route_for_sequence(
                     path_nodes = nx.shortest_path(G, cur, end, weight="weight")
                 edges_path = edges_from_path(G, path_nodes)
                 road_dist = sum(e.length_mi for e in edges_path if e.kind == "road")
-                if road_dist > max_road:
+                allowed_max_road = max_road
+                if last_seg is not None and degree.get(cur, 0) == 1 and last_seg.length_mi <= spur_length_thresh:
+                    allowed_max_road += spur_road_bonus
+                if road_dist > allowed_max_road:
                     continue
                 t = sum(
                     planner_utils.estimate_time(e, pace, grade, road_pace)
@@ -459,6 +485,7 @@ def _plan_route_for_sequence(
         if end == seg.start:
             route.append(seg)
             cur = seg.end
+            last_seg = seg
         else:
             if seg.direction != "both":
                 return []
@@ -476,6 +503,7 @@ def _plan_route_for_sequence(
             )
             route.append(rev)
             cur = rev.end
+            last_seg = seg
 
     if cur != start:
         try:
@@ -597,6 +625,8 @@ def plan_route(
     use_rpp: bool = False,
     allow_connectors: bool = True,
     rpp_timeout: float = 5.0,
+    spur_length_thresh: float = 0.3,
+    spur_road_bonus: float = 0.25,
 ) -> List[Edge]:
     """Plan an efficient loop through ``edges`` starting and ending at ``start``."""
 
@@ -626,6 +656,8 @@ def plan_route(
         max_road,
         road_threshold,
         dist_cache,
+        spur_length_thresh=spur_length_thresh,
+        spur_road_bonus=spur_road_bonus,
     )
     if not initial_route or len(seg_order) <= 2:
         return initial_route
@@ -651,6 +683,8 @@ def plan_route(
                     max_road,
                     road_threshold,
                     dist_cache,
+                    spur_length_thresh=spur_length_thresh,
+                    spur_road_bonus=spur_road_bonus,
                 )
                 if not candidate_route:
                     continue
@@ -850,6 +884,8 @@ def smooth_daily_plans(
             use_rpp=True,
             allow_connectors=allow_connector_trails,
             rpp_timeout=rpp_timeout,
+            spur_length_thresh=spur_length_thresh,
+            spur_road_bonus=spur_road_bonus,
         )
         if not route_edges:
             continue
@@ -1740,6 +1776,18 @@ def main(argv=None):
         help="Fractional speed advantage required to choose a road connector",
     )
     parser.add_argument(
+        "--spur-length-thresh",
+        type=float,
+        default=config_defaults.get("spur_length_thresh", 0.3),
+        help="Trail length in miles below which spur detours are considered",
+    )
+    parser.add_argument(
+        "--spur-road-bonus",
+        type=float,
+        default=config_defaults.get("spur_road_bonus", 0.25),
+        help="Additional road miles allowed when exiting a short spur",
+    )
+    parser.add_argument(
         "--road-pace",
         type=float,
         default=config_defaults.get("road_pace", 12.0),
@@ -2026,6 +2074,8 @@ def main(argv=None):
             use_rpp=False,
             allow_connectors=args.allow_connector_trails,
             rpp_timeout=args.rpp_timeout,
+            spur_length_thresh=args.spur_length_thresh,
+            spur_road_bonus=args.spur_road_bonus,
         )
         if initial_route:
             processed_clusters.append((cluster_segs, cluster_nodes))
@@ -2060,6 +2110,8 @@ def main(argv=None):
             use_rpp=False,
             allow_connectors=args.allow_connector_trails,
             rpp_timeout=args.rpp_timeout,
+            spur_length_thresh=args.spur_length_thresh,
+            spur_road_bonus=args.spur_road_bonus,
         )
         if extended_route:
             processed_clusters.append((cluster_segs, cluster_nodes))
@@ -2227,6 +2279,8 @@ def main(argv=None):
                     use_rpp=True,
                     allow_connectors=args.allow_connector_trails,
                     rpp_timeout=args.rpp_timeout,
+                    spur_length_thresh=args.spur_length_thresh,
+                    spur_road_bonus=args.spur_road_bonus,
                 )
                 if not route_edges:
                     if len(cluster_segs) == 1:
@@ -2261,6 +2315,8 @@ def main(argv=None):
                             use_rpp=True,
                             allow_connectors=args.allow_connector_trails,
                             rpp_timeout=args.rpp_timeout,
+                            spur_length_thresh=args.spur_length_thresh,
+                            spur_road_bonus=args.spur_road_bonus,
                         )
                         if extended_route:
                             route_edges = extended_route
@@ -2422,6 +2478,8 @@ def main(argv=None):
                         use_rpp=True,
                         allow_connectors=args.allow_connector_trails,
                         rpp_timeout=args.rpp_timeout,
+                        spur_length_thresh=args.spur_length_thresh,
+                        spur_road_bonus=args.spur_road_bonus,
                     )
                     if act_route_edges:
                         activities_for_this_day.append(


### PR DESCRIPTION
## Summary
- add planner config options `spur_length_thresh` and `spur_road_bonus`
- permit more road miles when leaving short spur segments
- expose command line flags `--spur-length-thresh` and `--spur-road-bonus`

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b4f56be308329900243dcd4d4da48