### PR TITLE
Fix planner smoothing args

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -931,6 +931,9 @@ def smooth_daily_plans(
     road_graph: Optional[nx.Graph] = None,
     average_driving_speed_mph: float = 30.0,
     home_coord: Optional[Tuple[float, float]] = None,
+    debug_args: argparse.Namespace | None = None,
+    spur_length_thresh: float = 0.3,
+    spur_road_bonus: float = 0.25,
 ) -> None:
     """Fill underutilized days with any remaining clusters."""
 
@@ -972,7 +975,7 @@ def smooth_daily_plans(
             use_rpp=True,
             allow_connectors=allow_connector_trails,
             rpp_timeout=rpp_timeout,
-            debug_args=args,
+            debug_args=debug_args,
             spur_length_thresh=spur_length_thresh,
             spur_road_bonus=spur_road_bonus,
         )
@@ -2666,6 +2669,9 @@ def main(argv=None):
         road_graph=road_graph_for_drive,
         average_driving_speed_mph=args.average_driving_speed_mph,
         home_coord=home_coord,
+        debug_args=args,
+        spur_length_thresh=args.spur_length_thresh,
+        spur_road_bonus=args.spur_road_bonus,
     )
 
     # After smoothing, ensure all segments have been scheduled. If any


### PR DESCRIPTION
## Summary
- fix undefined `args` when smoothing daily plans by adding parameters
- wire planner arguments through `smooth_daily_plans`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b56a0eea483299259a05334e1e6ff