### PR TITLE
Enable path precomputation by default

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -98,7 +98,7 @@ class PlannerConfig:
     average_driving_speed_mph: float = 30.0
     max_drive_minutes_per_transfer: float = 30.0
     review: bool = False
-    precompute_paths: bool = False
+    precompute_paths: bool = True
     redundancy_threshold: float = 0.2
     allow_connector_trails: bool = True
     rpp_timeout: float = 5.0
@@ -277,8 +277,12 @@ def _plan_route_greedy(
     last_seg: Optional[Edge] = None
     while remaining:
         paths = None
-        if dist_cache and cur in dist_cache:
-            paths = dist_cache[cur]
+        if dist_cache is not None:
+            if cur in dist_cache:
+                paths = dist_cache[cur]
+            else:
+                _, paths = nx.single_source_dijkstra(G, cur, weight="weight")
+                dist_cache[cur] = paths
         else:
             _, paths = nx.single_source_dijkstra(G, cur, weight="weight")
         candidate_info = []
@@ -393,7 +397,14 @@ def _plan_route_greedy(
             # For MultiGraph, one would do: G_for_path_back[edge_obj.start][edge_obj.end][key]['weight'] *= 10.0
 
     try:
-        path_back_nodes = nx.shortest_path(G_for_path_back, cur, start, weight="weight")
+        if dist_cache is not None:
+            if cur in dist_cache and start in dist_cache[cur]:
+                path_back_nodes = dist_cache[cur][start]
+            else:
+                path_back_nodes = nx.shortest_path(G_for_path_back, cur, start, weight="weight")
+                dist_cache.setdefault(cur, {})[start] = path_back_nodes
+        else:
+            path_back_nodes = nx.shortest_path(G_for_path_back, cur, start, weight="weight")
         path_back_edges = edges_from_path(
             G, path_back_nodes
         )  # Use original G for edge objects
@@ -401,7 +412,14 @@ def _plan_route_greedy(
     except nx.NetworkXNoPath:
         # Fallback to original graph if modified graph yields no path
         try:
-            path_back_nodes_orig = nx.shortest_path(G, cur, start, weight="weight")
+            if dist_cache is not None:
+                if cur in dist_cache and start in dist_cache[cur]:
+                    path_back_nodes_orig = dist_cache[cur][start]
+                else:
+                    path_back_nodes_orig = nx.shortest_path(G, cur, start, weight="weight")
+                    dist_cache.setdefault(cur, {})[start] = path_back_nodes_orig
+            else:
+                path_back_nodes_orig = nx.shortest_path(G, cur, start, weight="weight")
             route.extend(edges_from_path(G, path_back_nodes_orig))
         except nx.NetworkXNoPath:
             # No path back found even on original graph, or cur == start
@@ -439,8 +457,12 @@ def _plan_route_for_sequence(
             if end == seg.end and seg.direction != "both":
                 continue
             try:
-                if dist_cache and cur in dist_cache and end in dist_cache[cur]:
-                    path_nodes = dist_cache[cur][end]
+                if dist_cache is not None:
+                    if cur in dist_cache and end in dist_cache[cur]:
+                        path_nodes = dist_cache[cur][end]
+                    else:
+                        path_nodes = nx.shortest_path(G, cur, end, weight="weight")
+                        dist_cache.setdefault(cur, {})[end] = path_nodes
                 else:
                     path_nodes = nx.shortest_path(G, cur, end, weight="weight")
                 edges_path = edges_from_path(G, path_nodes)
@@ -466,8 +488,12 @@ def _plan_route_for_sequence(
                 if end == seg.end and seg.direction != "both":
                     continue
                 try:
-                    if dist_cache and cur in dist_cache and end in dist_cache[cur]:
-                        path_nodes = dist_cache[cur][end]
+                    if dist_cache is not None:
+                        if cur in dist_cache and end in dist_cache[cur]:
+                            path_nodes = dist_cache[cur][end]
+                        else:
+                            path_nodes = nx.shortest_path(G, cur, end, weight="weight")
+                            dist_cache.setdefault(cur, {})[end] = path_nodes
                     else:
                         path_nodes = nx.shortest_path(G, cur, end, weight="weight")
                     edges_path = edges_from_path(G, path_nodes)
@@ -521,7 +547,14 @@ def _plan_route_for_sequence(
 
     if cur != start:
         try:
-            path_back_nodes = nx.shortest_path(G, cur, start, weight="weight")
+            if dist_cache is not None:
+                if cur in dist_cache and start in dist_cache[cur]:
+                    path_back_nodes = dist_cache[cur][start]
+                else:
+                    path_back_nodes = nx.shortest_path(G, cur, start, weight="weight")
+                    dist_cache.setdefault(cur, {})[start] = path_back_nodes
+            else:
+                path_back_nodes = nx.shortest_path(G, cur, start, weight="weight")
             route.extend(edges_from_path(G, path_back_nodes))
         except nx.NetworkXNoPath:
             pass
@@ -972,9 +1005,6 @@ def smooth_daily_plans(
             use_rpp=True,
             allow_connectors=allow_connector_trails,
             rpp_timeout=rpp_timeout,
-            debug_args=args,
-            spur_length_thresh=spur_length_thresh,
-            spur_road_bonus=spur_road_bonus,
         )
         if not route_edges:
             continue
@@ -1940,7 +1970,7 @@ def main(argv=None):
     parser.add_argument(
         "--precompute-paths",
         action="store_true",
-        default=config_defaults.get("precompute_paths", False),
+        default=config_defaults.get("precompute_paths", True),
         help="Precompute all-pairs shortest paths between key graph nodes",
     )
     parser.add_argument(
@@ -2069,6 +2099,8 @@ def main(argv=None):
         for n in key_nodes:
             _, paths = nx.single_source_dijkstra(G, n, weight="weight")
             path_cache[n] = {t: paths[t] for t in key_nodes if t in paths}
+    else:
+        path_cache = {}
 
     tracking = planner_utils.load_segment_tracking(
         os.path.join("config", "segment_tracking.json"), args.segments

--- a/tests/test_plan_route_greedy.py
+++ b/tests/test_plan_route_greedy.py
@@ -112,7 +112,7 @@ def old_plan_route_greedy(G, edges, start, pace, grade, road_pace, max_road, roa
 def test_greedy_respects_max_road():
     G, trails = build_test_graph()
     params = dict(pace=10.0, grade=0.0, road_pace=15.0, max_road=1.0, road_threshold=0.1)
-    route, order = challenge_planner._plan_route_greedy(G, trails, (0.0, 0.0), **params, dist_cache=None)
+    route, order = challenge_planner._plan_route_greedy(G, trails, (0.0, 0.0), **params, dist_cache={})
 
     # The two trail segments require a 2-mile road connector which exceeds
     # ``max_road``. The greedy planner should therefore fail to produce a route.


### PR DESCRIPTION
## Summary
- default `--precompute-paths` to true
- cache shortest paths in memory even when not precomputing
- build an empty cache when `--precompute-paths` is off
- adjust tests for new default

## Testing
- `pip install -q networkx pandas gpxpy tqdm openai scikit-learn shapely tiktoken rasterio rtree matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b56eae710832993754900a47587cb