### PR TITLE
Introduce scoring for cluster selection

### DIFF
--- a/tests/test_cluster_score.py
+++ b/tests/test_cluster_score.py
@@ -1,0 +1,15 @@
+from trail_route_ai.challenge_planner import ClusterScore
+
+
+def test_isolation_and_completion_affect_score():
+    base = ClusterScore(10, 20, 0.0, 0.0, 0.0)
+    isolated = ClusterScore(10, 20, 5.0, 0.0, 0.0)
+    completed = ClusterScore(10, 20, 0.0, 1.0, 0.0)
+    assert isolated.total_score < base.total_score
+    assert completed.total_score < base.total_score
+
+
+def test_effort_distribution_penalty():
+    balanced = ClusterScore(10, 20, 0.0, 0.0, 0.0)
+    unbalanced = ClusterScore(10, 20, 0.0, 0.0, 5.0)
+    assert balanced.total_score < unbalanced.total_score


### PR DESCRIPTION
## Summary
- add `ClusterScore` dataclass for richer candidate evaluation
- include completion bonus and effort distribution during cluster selection
- sort by the computed `ClusterScore.total_score`
- test the scoring mechanics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b6feba79c832981e4149d710a6ef2