### PR TITLE
Add status messages for PBF processing

### DIFF
--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -96,8 +96,10 @@ def load_roads(path: str, bbox: Optional[List[float]] = None) -> List[Edge]:
     if path.lower().endswith(".pbf"):
         from pyrosm import OSM
 
+        print(f"Loading road network from PBF: {path}")
         osm = OSM(path, bounding_box=bbox)
         roads = osm.get_network(network_type="driving")
+        print("Converting road network to edges...")
         edges: List[Edge] = []
         idx = 0
         for _, row in roads.iterrows():
@@ -130,6 +132,7 @@ def load_roads(path: str, bbox: Optional[List[float]] = None) -> List[Edge]:
                     )
                 )
                 idx += 1
+        print(f"Finished processing {len(edges)} road edges")
         return edges
 
     # default: GeoJSON


### PR DESCRIPTION
## Summary
- print a message before and after processing OSM PBF data in `load_roads`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_684b75d1c9b88329a8663a3450c96c88