### PR TITLE
Add PBF clipping script

### DIFF
--- a/clip_pbf.py
+++ b/clip_pbf.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""Clip an OSM PBF file to the Boise trails region."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+import geopandas as gpd
+
+
+def clip_pbf(
+    pbf_path: str,
+    trails_path: str,
+    out_path: str = "osm_boise_clipped.pbf",
+    buffer_km: float = 3.0,
+) -> Path:
+    """Clip ``pbf_path`` to a bounding box around ``trails_path``.
+
+    Requires the ``osmium" command line tool to be installed.
+    The ``trails_path`` GeoJSON is used to compute the area of interest.
+    ``buffer_km`` expands the bounding box in all directions.
+    """
+    gdf = gpd.read_file(trails_path, engine="fiona")
+    minx, miny, maxx, maxy = gdf.total_bounds
+    deg = buffer_km / 111.32
+    minx -= deg
+    miny -= deg
+    maxx += deg
+    maxy += deg
+    bbox = f"{minx},{miny},{maxx},{maxy}"
+
+    out_path = Path(out_path).resolve()
+    cmd = ["osmium", "extract", "-b", bbox, pbf_path, "-o", str(out_path)]
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("osmium command not found; install osmium-tool") from exc
+
+    size_mb = out_path.stat().st_size / 1e6
+    print(f"Clipped OSM saved: {size_mb:.1f} MB -> {out_path}")
+    return out_path
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pbf", required=True, help="Input OSM PBF file")
+    parser.add_argument("--trails", required=True, help="Trail GeoJSON defining area")
+    parser.add_argument(
+        "--out", default="osm_boise_clipped.pbf", help="Output PBF path"
+    )
+    parser.add_argument(
+        "--buffer_km", type=float, default=3.0, help="Buffer distance in km"
+    )
+    args = parser.parse_args(argv)
+
+    clip_pbf(args.pbf, args.trails, args.out, args.buffer_km)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_clip_pbf.py
+++ b/tests/test_clip_pbf.py
@@ -1,0 +1,33 @@
+import subprocess
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+
+import clip_pbf
+
+
+def test_clip_pbf_invokes_osmium(monkeypatch, tmp_path):
+    # minimal GeoJSON for bounding box calculation
+    trails = tmp_path / "trails.geojson"
+    gdf = gpd.GeoDataFrame(geometry=[])
+    gdf.to_file(trails, driver="GeoJSON")
+
+    pbf = tmp_path / "in.pbf"
+    pbf.write_text("")
+    out = tmp_path / "out.pbf"
+
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+        out.write_text("")
+        return None
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    clip_pbf.clip_pbf(str(pbf), str(trails), str(out), buffer_km=0.0)
+
+    assert calls
+    assert calls[0][0] == "osmium"
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add `clip_pbf.py` utility to cut a large OSM file down to the Boise AOI
- test that clipping function invokes `osmium`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b7c8266d48329b2b1f3b0f86126a0