### PR TITLE
Fix missing dependency for geopandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ rtree
 networkx
 scikit-learn
 rasterio
+geopandas
 numpy
 elevation
 pyrosm


### PR DESCRIPTION
## Summary
- include `geopandas` in `requirements.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9050dbbc8329b9f417edbad3edc6