### PR TITLE
Improve progress reporting during cluster planning

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -2403,7 +2403,12 @@ def main(argv=None):
     # a greedy time-based split which keeps each resulting cluster under the
     # provided budget whenever possible.
     expanded_clusters: List[Tuple[List[Edge], Set[Tuple[float, float]]]] = []
-    for cluster_edges, cluster_nodes in potential_macro_clusters:
+    expansion_iter = tqdm(
+        potential_macro_clusters,
+        desc="Expanding clusters",
+        unit="cluster",
+    )
+    for cluster_edges, cluster_nodes in expansion_iter:
         if not cluster_edges:
             continue
         naive_time = total_time(cluster_edges, args.pace, args.grade, args.road_pace)


### PR DESCRIPTION
## Summary
- add a progress bar when splitting large macro clusters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpxpy')*
- `pip install -r requirements.txt` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684c507377388329b6ac958e6228978e