### PR TITLE
feat: Improve planner logging and RPP configuration

### DIFF
--- a/config/planner_config_old.json
+++ b/config/planner_config_old.json
@@ -29,7 +29,5 @@
   "start_date": "2025-06-19",
   "time": "4h",
   "trailheads": null,
-  "use_rpp": true,
-  "use_rpp_for_initial_processing": false,
   "year": null
 }


### PR DESCRIPTION
This commit introduces several enhancements to the trail challenge planner:

1.  **Detailed Logging:**
    - Added extensive debug logging in `plan_route` to trace the decision-making process regarding tree traversal, RPP (Rural Postman Problem) usage, and fallbacks to the greedy algorithm. This includes reasons for RPP skips (e.g., connectivity, timeout) and RPP execution times.
    - Enhanced logging within `_plan_route_greedy` to monitor `dist_cache` effectiveness (hits, misses, population) and the number of candidates being evaluated.
    - Ensured `debug_args` is passed down to `_plan_route_greedy` so its logs respect global debug/verbose flags.

2.  **Greedy Algorithm Cleanup:**
    - Removed a redundant `tqdm` progress bar (`greedy_selection_progress`) from `_plan_route_greedy`, simplifying output and relying on the primary progress bar.

3.  **RPP Configuration:**
    - Made RPP usage more configurable: - Added a global `use_rpp` option (boolean, default True) to `planner_config.json` and as a command-line argument (`--use-rpp`/`--no-use-rpp`). - Added `use_rpp_for_initial_processing` option (boolean, default False) to `planner_config.json` and as a command-line argument (`--use-rpp-for-initial-processing`/`--no-use-rpp-for-initial-processing`) to control RPP usage specifically during the initial cluster validation phase.
    - All calls to `plan_route` now respect these configuration settings.
    - Added a comment to `rpp_timeout` in argparse help to suggest increasing it if RPP timeouts are frequent.

These changes aim to provide you with better insights into the planner's behavior, offer more control over the routing strategies employed, and reduce unnecessary fallbacks to the potentially slower greedy algorithm by making RPP usage more flexible.