### PR TITLE
Improve logging in route planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Below is a full list of command-line flags available for the challenge planner s
 * `--debug PATH` – Write per-day route rationale to the given file.
 * `--verbose` – Echo debug log messages to the console.
 * `--advanced-optimizer` – Enable the experimental multi-objective 2‑opt optimizer for reduced redundancy.
+* `--path-cache FILE` – Shelve database for caching shortest paths (default `config/path_cache.db`).
+* `--clear-cache` – Remove the path cache before running.
 
 ## Road Connectors
 

--- a/src/trail_route_ai/__init__.py
+++ b/src/trail_route_ai/__init__.py
@@ -11,6 +11,7 @@ from .optimizer import (
     is_pareto_improvement,
     advanced_2opt_optimization,
 )
+from .path_cache import PathCache
 
 __all__ = [
     "Edge",
@@ -20,4 +21,5 @@ __all__ = [
     "RouteMetrics",
     "is_pareto_improvement",
     "advanced_2opt_optimization",
+    "PathCache",
 ]

--- a/src/trail_route_ai/path_cache.py
+++ b/src/trail_route_ai/path_cache.py
@@ -1,0 +1,69 @@
+import shelve
+from typing import Dict, Tuple, List, Optional
+
+from tqdm.auto import tqdm
+
+class PathCache:
+    """Persistent cache for shortest paths keyed by start and end nodes.
+
+    Parameters
+    ----------
+    filename:
+        The shelve database file to store path data.
+    log:
+        If ``True`` (default), log cache hits/misses with ``tqdm.write``.
+    """
+
+    def __init__(self, filename: str, *, log: bool = True):
+        self.db = shelve.open(filename)
+        self.log = log
+
+    def get_paths_from(self, start: Tuple[float, float]) -> Dict[Tuple[float, float], List[Tuple[float, float]]]:
+        key = repr(start)
+        paths = self.db.get(key)
+        if paths is not None:
+            if self.log:
+                tqdm.write(f"PathCache hit: paths from {start}")
+            return paths
+        if self.log:
+            tqdm.write(f"PathCache miss: paths from {start}")
+        return {}
+
+    def store_paths_from(self, start: Tuple[float, float], paths: Dict[Tuple[float, float], List[Tuple[float, float]]]) -> None:
+        self.db[repr(start)] = paths
+        if self.log:
+            tqdm.write(f"PathCache store: paths from {start}")
+
+    def get(self, start: Tuple[float, float], end: Tuple[float, float]) -> Optional[List[Tuple[float, float]]]:
+        key = repr(start)
+        paths = self.db.get(key)
+        if paths and end in paths:
+            if self.log:
+                tqdm.write(f"PathCache hit: {start} -> {end}")
+            return paths[end]
+        if self.log:
+            tqdm.write(f"PathCache miss: {start} -> {end}")
+        return None
+
+    def set(self, start: Tuple[float, float], end: Tuple[float, float], path: List[Tuple[float, float]]) -> None:
+        key = repr(start)
+        paths = self.db.get(key, {})
+        paths[end] = path
+        self.db[key] = paths
+        if self.log:
+            tqdm.write(f"PathCache store: {start} -> {end}")
+
+    def close(self) -> None:
+        self.db.close()
+
+    def clear(self) -> None:
+        """Remove all cached paths."""
+        self.db.clear()
+        if self.log:
+            tqdm.write("PathCache cleared")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()


### PR DESCRIPTION
## Summary
- extend `_plan_route_greedy` and `_plan_route_for_sequence` with `debug_args`
- log cache hits/misses and candidate evaluation in greedy and sequence planners
- report when the greedy planner finishes routing
- note skipped paths due to road limits and path selection in 2‑opt sequences

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -k plan_route_rpp -q` *(fails: ModuleNotFoundError for networkx, pandas, gpxpy, geopandas)*

------
https://chatgpt.com/codex/tasks/task_e_684dca2b7b6c8329ae893b26e8cc3e59