### PR TITLE
Implement cache logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ pytest -q
 
 This will execute the unit tests to verify that everything is working properly.
 
+## Cache
+
+The planner caches expensive intermediate data such as shortest path results
+under `~/.boise_trails_ai_cache` by default. Cached values are reused across
+runs when the same parameters are supplied, greatly speeding up subsequent
+executions. Cache load/save events are logged when running with `--verbose`.
+You can remove all cached data at any time:
+
+```bash
+python -m trail_route_ai.cache_utils --clear
+```
+
+Set the `BTAI_CACHE_DIR` environment variable to override the cache location.
+
 ## GPX to CSV Utility
 
 If you have recorded GPS tracks from previous activities or past Boise Trails Challenges, you can use the GPX-to-CSV utility to consolidate your completed segments into a performance log. This is useful for updating the planner with segments you’ve already done.

--- a/src/trail_route_ai/__init__.py
+++ b/src/trail_route_ai/__init__.py
@@ -11,6 +11,7 @@ from .optimizer import (
     is_pareto_improvement,
     advanced_2opt_optimization,
 )
+from . import cache_utils
 
 __all__ = [
     "Edge",
@@ -20,4 +21,5 @@ __all__ = [
     "RouteMetrics",
     "is_pareto_improvement",
     "advanced_2opt_optimization",
+    "cache_utils",
 ]

--- a/src/trail_route_ai/cache_utils.py
+++ b/src/trail_route_ai/cache_utils.py
@@ -1,0 +1,67 @@
+import argparse
+import hashlib
+import os
+import pickle
+import shutil
+import logging
+from typing import Any
+
+
+DEFAULT_CACHE_DIR = os.environ.get(
+    "BTAI_CACHE_DIR", os.path.expanduser("~/.boise_trails_ai_cache")
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_cache_dir() -> str:
+    os.makedirs(DEFAULT_CACHE_DIR, exist_ok=True)
+    return DEFAULT_CACHE_DIR
+
+
+def _cache_path(name: str, key: str) -> str:
+    h = hashlib.sha1(key.encode()).hexdigest()[:16]
+    return os.path.join(get_cache_dir(), f"{name}_{h}.pkl")
+
+
+def load_cache(name: str, key: str) -> Any | None:
+    path = _cache_path(name, key)
+    if os.path.exists(path):
+        try:
+            with open(path, "rb") as f:
+                data = pickle.load(f)
+            logger.info("Loaded cache %s:%s", name, key)
+            return data
+        except Exception:
+            return None
+    return None
+
+
+def save_cache(name: str, key: str, data: Any) -> None:
+    path = _cache_path(name, key)
+    try:
+        with open(path, "wb") as f:
+            pickle.dump(data, f)
+        logger.info("Saved cache %s:%s", name, key)
+    except Exception:
+        pass
+
+
+def clear_cache() -> None:
+    dir_path = get_cache_dir()
+    if os.path.isdir(dir_path):
+        shutil.rmtree(dir_path)
+        logger.info("Cleared cache directory %s", dir_path)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Manage boise-trails-ai cache")
+    parser.add_argument("--clear", action="store_true", help="remove all cached data")
+    args = parser.parse_args(argv)
+    if args.clear:
+        clear_cache()
+        print(f"Cache cleared: {get_cache_dir()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,13 @@
+import os
+from trail_route_ai import cache_utils
+
+
+def test_cache_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("BTAI_CACHE_DIR", str(tmp_path))
+    cache_utils.clear_cache()
+    data = {"foo": 1}
+    cache_utils.save_cache("dist", "key", data)
+    loaded = cache_utils.load_cache("dist", "key")
+    assert loaded == data
+    cache_utils.clear_cache()
+    assert not any(tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- add logging to cache utils
- log path cache load/save in challenge planner
- document verbose cache logs in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684dec1e052883299ea693e04b1325c3