### PR TITLE
Fix cache dir override and add test

### DIFF
--- a/src/trail_route_ai/cache_utils.py
+++ b/src/trail_route_ai/cache_utils.py
@@ -7,16 +7,20 @@ import logging
 from typing import Any
 
 
-DEFAULT_CACHE_DIR = os.environ.get(
-    "BTAI_CACHE_DIR", os.path.expanduser("~/.boise_trails_ai_cache")
-)
+# Default location for cached data when no environment override is provided
+DEFAULT_CACHE_DIR = os.path.expanduser("~/.boise_trails_ai_cache")
 
 logger = logging.getLogger(__name__)
 
 
 def get_cache_dir() -> str:
-    os.makedirs(DEFAULT_CACHE_DIR, exist_ok=True)
-    return DEFAULT_CACHE_DIR
+    """Return the directory used for cached files."""
+
+    # Re-read the environment variable each call so tests or callers may
+    # override the location after this module is imported.
+    path = os.environ.get("BTAI_CACHE_DIR", DEFAULT_CACHE_DIR)
+    os.makedirs(path, exist_ok=True)
+    return path
 
 
 def _cache_path(name: str, key: str) -> str:

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 from trail_route_ai import cache_utils
 
 
@@ -7,7 +8,9 @@ def test_cache_roundtrip(tmp_path, monkeypatch):
     cache_utils.clear_cache()
     data = {"foo": 1}
     cache_utils.save_cache("dist", "key", data)
+    cache_file = tmp_path / f"dist_{hashlib.sha1('key'.encode()).hexdigest()[:16]}.pkl"
+    assert cache_file.exists()
     loaded = cache_utils.load_cache("dist", "key")
     assert loaded == data
     cache_utils.clear_cache()
-    assert not any(tmp_path.iterdir())
+    assert not tmp_path.exists()


### PR DESCRIPTION
## Summary
- fix cache directory resolution to read `BTAI_CACHE_DIR` each call
- verify cache location in `test_cache_utils`

## Testing
- `pytest tests/test_cache_utils.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dff1569188329a3b0536aa576c950