### PR TITLE
Fix parse_time_budget to handle spaces

### DIFF
--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -665,7 +665,7 @@ def parse_time_budget(value: str) -> float:
     ``H:MM`` notation ("1:30").
     """
 
-    text = value.strip().lower()
+    text = value.strip().lower().replace(" ", "")
     # Formats like "1h30" or "2h15m"
     m = re.match(r"^(\d+(?:\.\d+)?)h(?:([0-5]?\d)(?:m)?)?$", text)
     if m:

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -9,3 +9,6 @@ def test_parse_time_budget_formats():
     assert planner_utils.parse_time_budget('1:45') == pytest.approx(105.0)
     assert planner_utils.parse_time_budget('90') == pytest.approx(90.0)
     assert planner_utils.parse_time_budget('1.5h') == pytest.approx(90.0)
+
+def test_parse_time_budget_with_spaces():
+    assert planner_utils.parse_time_budget('1h 30') == pytest.approx(90.0)


### PR DESCRIPTION
## Summary
- allow spaces in parse_time_budget
- add regression test for time strings containing spaces

## Testing
- `pytest tests/test_time_utils.py tests/test_planner_utils_extra.py tests/test_plan_route_tree.py tests/test_plan_route_greedy.py tests/test_cluster_score.py tests/test_route_optimization.py tests/test_gpx_to_csv.py tests/test_cache_utils.py tests/test_plan_review.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684e034bec1c83299f4eb79206e5f4fa