### PR TITLE
Fix challenge_planner standalone import

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -9,7 +9,10 @@ from dataclasses import dataclass, asdict
 from collections import defaultdict
 from typing import Dict, List, Tuple, Set, Optional
 
-from . import cache_utils
+# When executed as a script, ``__package__`` is not set, which breaks relative
+# imports. Import ``cache_utils`` using its absolute name so the script works
+# both as part of the package and when run standalone.
+from trail_route_ai import cache_utils
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- fix relative `cache_utils` import in challenge_planner

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_684e384609b08329a4ef2056ea103138