### PR TITLE
Fix challenge planner imports

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -2,6 +2,12 @@ import argparse
 import csv
 import os
 import sys
+
+# When executed directly, ``trail_route_ai`` may not be on the module search
+# path. Insert the project ``src`` directory so absolute imports work even when
+# running this file as ``python challenge_planner.py``.
+if __package__ in (None, ""):
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import datetime
 import json
 import time


### PR DESCRIPTION
## Summary
- ensure standalone execution of `challenge_planner.py` adjusts PYTHONPATH

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_684e38fa1e0083298e2c9982a5d3ff6f