### PR TITLE
Add editable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Before using the planner, set up the Python environment and dependencies:
    bash run/setup.sh
    ```
 
+Once dependencies are installed, install the project in editable mode so the
+`trail_route_ai` package is available on your `PYTHONPATH`:
+
+```bash
+pip install -e .
+```
+
+This command uses the project's `pyproject.toml` and `setup.py` to install
+`boise-trails-ai` in editable mode.
+
+All examples below assume the package has been installed this way.
+
 ## Download Data Assets
 
 Certain data files are required for the planner but are not included in the repository. Run the helper script to fetch these external assets:
@@ -112,7 +124,9 @@ Use the `--rebuild` flag if you want to regenerate the entries for that year fro
 
 Once your environment is set up and data is in place, you can generate your challenge plan. The planner is run via a command-line interface. At minimum you should specify the start date and end date of the challenge period. You can also provide your typical pace and daily time budget (or use defaults).
 
-For example, to plan a challenge for July 2024 with a 4-hour daily running window and a 10 min/mile base pace (with 30 seconds added per 100 ft of climb), you could run:
+Run the planner directly with Python. For example, to plan a challenge for July
+2024 with a 4‑hour daily running window and a 10 min/mile base pace (with 30
+seconds added per 100 ft of climb), run:
 
 ```bash
 python -m trail_route_ai.challenge_planner --start-date 2024-07-01 --end-date 2024-07-31 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+import pathlib
+from setuptools import setup, find_packages
+
+here = pathlib.Path(__file__).parent
+
+# Read requirements from requirements.txt
+req_file = here / "requirements.txt"
+with req_file.open() as f:
+    requirements = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+
+setup(
+    name="boise-trails-ai",
+    version="0.1.0",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    install_requires=requirements,
+)


### PR DESCRIPTION
## Summary
- remove `run/planner.sh` wrapper
- support `pip install -e .` with a simple `setup.py`
- document installing in editable mode and running the planner directly
- add build metadata to `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_684e397ca080832997e309e89a716a68