### PR TITLE
Fix: Prevent RPP failure when required node is not in graph

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -704,8 +704,19 @@ def plan_route_rpp(
 
     if allow_connectors and not timed_out():
         debug_log(debug_args, "RPP: Calculating Steiner tree...")
+        valid_required_nodes = set()
+        for node in required_nodes:
+            if node in UG.nodes():
+                valid_required_nodes.add(node)
+            else:
+                debug_log(debug_args, f"RPP: Required node {node} not in UG. Removing from Steiner tree calculation.")
+
+        if len(valid_required_nodes) < 2:
+            debug_log(debug_args, "RPP: Not enough valid required nodes for Steiner tree calculation after filtering. Returning empty list.")
+            return []
+
         steiner = nx.algorithms.approximation.steiner_tree(
-            UG, required_nodes, weight="weight"
+            UG, valid_required_nodes, weight="weight"
         )
         sub.add_edges_from(steiner.edges(data=True))
         debug_log(debug_args, "RPP: Steiner tree calculation complete.")


### PR DESCRIPTION
The `plan_route_rpp` function could fail with a `NodeNotFound` error during the Steiner tree calculation if one of the `required_nodes` (derived from the input edges for the RPP cluster) was not present in the underlying graph `UG`. This could happen if an input `Edge` object referred to a node that wasn't part of any actual segments in the main routing graph `G`.

This commit modifies `plan_route_rpp` to filter `required_nodes` before calling `nx.algorithms.approximation.steiner_tree`, ensuring all nodes passed to the Steiner tree function exist in `UG`. Debug logging was added to record any nodes removed during this filtering step.

A new test case, `test_plan_route_rpp_node_not_in_graph`, was added to `tests/test_challenge_planner.py`. This test creates a scenario where an edge intended for RPP contains a node not present in the graph `G`. It verifies:
- The `NodeNotFound` exception is no longer raised.
- The debug log correctly indicates the problematic node was identified and removed from Steiner tree consideration.
- The RPP process either completes successfully with the valid nodes or falls back gracefully, and the problematic edge is not included in the final route.