### PR TITLE
Fix: Handle disconnected components in RPP Steiner tree calculation

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -741,6 +741,52 @@ def plan_route_rpp(
             debug_log(debug_args, "RPP: Not enough valid required nodes for Steiner tree calculation after filtering. Returning empty list.")
             return []
 
+            # Check if UG has any nodes. If not, and valid_required_nodes exist, it's an inconsistency.
+            # If UG is empty and valid_required_nodes is also empty, it's fine to proceed or return early.
+            if not UG.nodes():
+                if valid_required_nodes: # Should not happen if valid_required_nodes are filtered by UG.nodes()
+                    debug_log(debug_args, "RPP: UG graph is empty, but valid_required_nodes is not. Inconsistency found. Returning empty list.")
+                    return []
+                else: # UG is empty, and valid_required_nodes is also empty.
+                    debug_log(debug_args, "RPP: UG graph is empty and no valid required nodes. Returning empty list.")
+                    return []
+
+            # Check if all valid_required_nodes are in the same connected component of UG
+            if valid_required_nodes: # Only proceed if there are nodes to check connectivity for
+                components = list(nx.connected_components(UG))
+
+                # This case (UG has nodes but components list is empty) should be extremely rare with NetworkX.
+                if not components and UG.nodes():
+                    debug_log(debug_args, "RPP: UG has nodes, but no connected components were found. This is unexpected. Returning empty list.")
+                    return []
+
+                # If valid_required_nodes is not empty, at least one component should exist if nodes are in UG.
+                # And if components list is empty, valid_required_nodes must also be empty (or nodes are not in UG).
+                if not components and valid_required_nodes: # Defensive check
+                    debug_log(debug_args, "RPP: No components found in UG, but valid_required_nodes exist. Nodes might not be in UG. Returning empty list.")
+                    return []
+
+                first_node = next(iter(valid_required_nodes))
+                target_component_set = None
+                node_found_in_any_component = False
+                for comp_set in components:
+                    if first_node in comp_set:
+                        target_component_set = comp_set
+                        node_found_in_any_component = True
+                        break
+
+                if not node_found_in_any_component:
+                    # This implies first_node (which is in valid_required_nodes, meaning it was in UG.nodes())
+                    # was not found in any component. This is theoretically impossible if nx.connected_components works as expected for non-empty graphs.
+                    debug_log(debug_args, f"RPP: Critical error - Required node {first_node} (known to be in UG) was not found in any connected component. Returning empty list.")
+                    return []
+
+                for node in valid_required_nodes:
+                    if node not in target_component_set:
+                        debug_log(debug_args, f"RPP: Required nodes span multiple disconnected components in UG. Node {node} is not in the component of {first_node}. Cannot compute Steiner tree. Returning empty list.")
+                        return []
+                debug_log(debug_args, "RPP: All valid required nodes are confirmed to be in the same connected component of UG.")
+
         try:
             steiner = nx.algorithms.approximation.steiner_tree(
                 UG, valid_required_nodes, weight="weight"


### PR DESCRIPTION
The `plan_route_rpp` function was failing with a `KeyError` during the Steiner tree calculation when required nodes spanned multiple disconnected components of the underlying graph.

This commit introduces a check prior to calling `nx.algorithms.approximation.steiner_tree`. The new check verifies that all `valid_required_nodes` belong to the same connected component of the graph `UG`. If they do not, `plan_route_rpp` now returns an empty list early, preventing the error.

Additionally, a new unit test `test_plan_route_rpp_disconnected_components` has been added to `tests/test_challenge_planner.py` to specifically verify this scenario and ensure the fix works as expected.