### PR TITLE
Improve setup script for dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Before using the planner, set up the Python environment and dependencies:
 
    This will install all required libraries as listed in `requirements.txt` (which is generated from `requirements.toml`).
 
-   Alternatively, you can run the provided setup script to create the environment and install dependencies in one step:
+Alternatively, you can run the provided setup script to create the environment and install dependencies in one step. The script now installs
+system packages such as GDAL and PROJ via `apt-get` before using `pip` for the Python requirements:
 
    ```bash
    bash run/setup.sh

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Install system packages needed for compiling geospatial Python libraries
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    python3.12-dev \
+    gdal-bin libgdal-dev \
+    libgeos-dev \
+    libspatialindex-dev \
+    proj-bin libproj-dev
+
 # Determine path to requirements.toml relative to this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REQ_FILE="$SCRIPT_DIR/../requirements.toml"


### PR DESCRIPTION
## Summary
- update setup script to install apt dependencies before pip
- mention system packages in README

## Testing
- `pytest -k test_plan_route_fallback_on_rpp_failure -vv` *(fails: AssertionError: Expected 'plan_route_rpp' to have been called once. Called 0 times.)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7ad9280832989b4ef6ac6e2c0dc