### PR TITLE
Add greedy fallback test

### DIFF
--- a/run/setup.sh
+++ b/run/setup.sh
@@ -38,3 +38,6 @@ fi
 
 pip install $packages
 
+# Install testing utilities
+pip install pytest pytest-timeout
+

--- a/tests/test_plan_route_greedy.py
+++ b/tests/test_plan_route_greedy.py
@@ -286,3 +286,47 @@ def test_overlimit_road_chosen_when_much_faster():
 
     names = [e.name for e in route]
     assert "R1" in names
+
+
+def test_greedy_fallback_handles_unreachable_segment():
+    """Greedy fallback should exit cleanly when a segment cannot be reached."""
+    seg_a = planner_utils.Edge(
+        "A",
+        "A",
+        (0.0, 0.0),
+        (1.0, 0.0),
+        1.0,
+        0.0,
+        [(0.0, 0.0), (1.0, 0.0)],
+        "trail",
+        "both",
+    )
+    seg_b = planner_utils.Edge(
+        "B",
+        "B",
+        (5.0, 0.0),
+        (6.0, 0.0),
+        1.0,
+        0.0,
+        [(5.0, 0.0), (6.0, 0.0)],
+        "trail",
+        "both",
+    )
+    G = challenge_planner.build_nx_graph(
+        [seg_a, seg_b], pace=10.0, grade=0.0, road_pace=15.0
+    )
+
+    route = challenge_planner.plan_route(
+        G,
+        [seg_a, seg_b],
+        (0.0, 0.0),
+        pace=10.0,
+        grade=0.0,
+        road_pace=15.0,
+        max_road=1.0,
+        road_threshold=0.1,
+        use_rpp=False,
+    )
+
+    # With B unreachable the planner should return an empty list quickly.
+    assert route == []


### PR DESCRIPTION
## Summary
- add `pytest` and `pytest-timeout` install to setup script
- test greedy fallback when a segment is unreachable

## Testing
- `pip install pandas gpxpy shapely rtree networkx scikit-learn numpy tqdm`
- `pip install openai tiktoken`
- `pytest tests/test_plan_route_greedy.py::test_greedy_fallback_handles_unreachable_segment -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684ef298324c832997c5bd0dd91e4eb0