### PR TITLE
Fix: Correct TypeError in debug_log call

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -362,7 +362,6 @@ def _plan_route_greedy(
             debug_log(
                 debug_args,
                 f"_plan_route_greedy: starting iteration {iteration_count}/{max_iterations} with {len(remaining)} remaining segments from {cur}",
-                f"_plan_route_greedy: starting iteration {iteration_count}/{max_iterations} with {len(remaining)} remaining segments from {cur}",
             )
             paths = None
             if dist_cache is not None and cur in dist_cache:


### PR DESCRIPTION
The debug_log function was being called with three arguments instead of the expected two within the _plan_route_greedy function. This was due to a duplicated argument in the function call.

This commit removes the redundant third argument to resolve the TypeError.