### PR TITLE
Rename max-road argument to max-foot-road

### DIFF
--- a/config/planner_config.json
+++ b/config/planner_config.json
@@ -11,7 +11,7 @@
   "home_lon": -116.205,
   "mark_road_transitions": true,
   "max_drive_minutes_per_transfer": 30.0,
-  "max_road": 3.0,
+  "max_foot_road": 3.0,
   "output": "challenge_plan.csv",
   "output_dir": null,
   "pace": 10,

--- a/src/trail_route_ai/optimizer.py
+++ b/src/trail_route_ai/optimizer.py
@@ -21,7 +21,7 @@ def calculate_route_metrics(
     ctx: planner_utils.PlanningContext,
     route: Iterable[Edge],
     required_ids: Set[str],
-    max_road: float,
+    max_foot_road: float,
 ) -> RouteMetrics:
     """Compute metrics for ``route`` using planning context values."""
 
@@ -45,7 +45,7 @@ def calculate_route_metrics(
     elevation_gain = sum(e.elev_gain_ft for e in edges)
 
     connectivity_subs = challenge_planner.split_cluster_by_connectivity(
-        [e for e in edges if e.kind != "road"], ctx.graph, max_road
+        [e for e in edges if e.kind != "road"], ctx.graph, max_foot_road
     )
     connectivity = 1.0 / len(connectivity_subs) if connectivity_subs else 0.0
 
@@ -97,7 +97,7 @@ def build_route_from_order(
     ctx: planner_utils.PlanningContext,
     sequence: List[Edge],
     start: Tuple[float, float],
-    max_road: float,
+    max_foot_road: float,
     road_threshold: float,
     spur_length_thresh: float = 0.3,
     spur_road_bonus: float = 0.25,
@@ -111,7 +111,7 @@ def build_route_from_order(
         ctx.pace,
         ctx.grade,
         ctx.road_pace,
-        max_road,
+        max_foot_road,
         road_threshold,
         ctx.dist_cache,
         spur_length_thresh=spur_length_thresh,
@@ -124,18 +124,18 @@ def advanced_2opt_optimization(
     order: List[Edge],
     start: Tuple[float, float],
     required_ids: Set[str],
-    max_road: float,
+    max_foot_road: float,
     road_threshold: float,
 ) -> Tuple[List[Edge], List[Edge]]:
     """Perform a multi-objective 2-opt optimization on ``order``."""
 
     best_order = order[:]
     best_route = build_route_from_order(
-        ctx, best_order, start, max_road, road_threshold
+        ctx, best_order, start, max_foot_road, road_threshold
     )
     if not best_route:
         return [], []
-    best_metrics = calculate_route_metrics(ctx, best_route, required_ids, max_road)
+    best_metrics = calculate_route_metrics(ctx, best_route, required_ids, max_foot_road)
 
     improved = True
     while improved:
@@ -148,13 +148,13 @@ def advanced_2opt_optimization(
                 ctx,
                 new_order,
                 start,
-                max_road,
+                max_foot_road,
                 road_threshold,
             )
             if not cand_route:
                 continue
             cand_metrics = calculate_route_metrics(
-                ctx, cand_route, required_ids, max_road
+                ctx, cand_route, required_ids, max_foot_road
             )
             if is_pareto_improvement(best_metrics, cand_metrics):
                 best_metrics = cand_metrics

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -594,7 +594,7 @@ def test_unrouteable_cluster_split(tmp_path):
             str(out_csv),
             "--gpx-dir",
             str(gpx_dir),
-            "--max-road",
+            "--max-foot-road",
             "0.01",
         ]
     )
@@ -747,7 +747,7 @@ def test_advanced_optimizer_reduces_redundancy():
     G = challenge_planner.build_nx_graph(edges, pace=10.0, grade=0.0, road_pace=10.0)
 
     base = challenge_planner.plan_route(
-        G, edges, (0.0, 0.0), pace=10.0, grade=0.0, road_pace=10.0, max_road=0.0, road_threshold=0.1
+        G, edges, (0.0, 0.0), pace=10.0, grade=0.0, road_pace=10.0, max_foot_road=0.0, road_threshold=0.1
     )
     adv = challenge_planner.plan_route(
         G,
@@ -756,7 +756,7 @@ def test_advanced_optimizer_reduces_redundancy():
         pace=10.0,
         grade=0.0,
         road_pace=10.0,
-        max_road=0.0,
+        max_foot_road=0.0,
         road_threshold=0.1,
         use_advanced_optimizer=True,
     )
@@ -866,7 +866,7 @@ def test_plan_route_rpp_node_not_in_graph(tmp_path):
     pace_val = 10.0
     grade_val = 0.0
     road_pace_val = 12.0
-    max_road_val = 1.0 # Allow some road for connectors if needed by greedy fallback
+    max_foot_road_val = 1.0 # Allow some road for connectors if needed by greedy fallback
     road_threshold_val = 0.25
     rpp_timeout_val = 2.0 # Short timeout for test
 
@@ -887,7 +887,7 @@ def test_plan_route_rpp_node_not_in_graph(tmp_path):
             pace=pace_val,
             grade=grade_val,
             road_pace=road_pace_val,
-            max_road=max_road_val,
+            max_foot_road=max_foot_road_val,
             road_threshold=road_threshold_val,
             dist_cache=None,
             use_rpp=True,
@@ -982,7 +982,7 @@ def test_plan_route_fallback_on_rpp_failure(tmp_path):
             pace=10.0,
             grade=0.0,
             road_pace=12.0,
-            max_road=1.0,
+            max_foot_road=1.0,
             road_threshold=0.25,
             dist_cache=None,
             use_rpp=True,  # Critical: RPP is enabled

--- a/tests/test_plan_route_greedy.py
+++ b/tests/test_plan_route_greedy.py
@@ -138,7 +138,7 @@ def build_graph_with_trail_connector(trail_len: float) -> tuple[nx.DiGraph, list
 
 
 def old_plan_route_greedy(
-    G, edges, start, pace, grade, road_pace, max_road, road_threshold
+    G, edges, start, pace, grade, road_pace, max_foot_road, road_threshold
 ):
     remaining = edges[:]
     route = []
@@ -156,7 +156,7 @@ def old_plan_route_greedy(
                     road_dist = sum(
                         ed.length_mi for ed in edges_path if ed.kind == "road"
                     )
-                    if road_dist > max_road:
+                    if road_dist > max_foot_road:
                         continue
                     time = sum(
                         planner_utils.estimate_time(ed, pace, grade, road_pace)
@@ -246,14 +246,14 @@ def old_plan_route_greedy(
 def test_greedy_allows_overlimit_when_no_trail():
     G, trails = build_test_graph()
     params = dict(
-        pace=10.0, grade=0.0, road_pace=15.0, max_road=1.0, road_threshold=0.1
+        pace=10.0, grade=0.0, road_pace=15.0, max_foot_road=1.0, road_threshold=0.1
     )
     route, order = challenge_planner._plan_route_greedy(
         G, trails, (0.0, 0.0), **params, dist_cache={}
     )
 
     # With no trail connector available, the planner should use the road
-    # connector even though it exceeds ``max_road``.
+    # connector even though it exceeds ``max_foot_road``.
     assert route
     assert order == trails
 
@@ -262,7 +262,7 @@ def test_overlimit_road_vs_trail_fallback():
     """When a trail connector is nearly as fast, the planner should prefer it."""
     G, trails = build_graph_with_trail_connector(trail_len=1.45)
     params = dict(
-        pace=10.0, grade=0.0, road_pace=15.0, max_road=1.0, road_threshold=0.1
+        pace=10.0, grade=0.0, road_pace=15.0, max_foot_road=1.0, road_threshold=0.1
     )
     route, _ = challenge_planner._plan_route_greedy(
         G, trails, (0.0, 0.0), **params, dist_cache={}
@@ -278,7 +278,7 @@ def test_overlimit_road_chosen_when_much_faster():
     """Road connector is used when significantly faster than trail alternative."""
     G, trails = build_graph_with_trail_connector(trail_len=5.0)
     params = dict(
-        pace=10.0, grade=0.0, road_pace=15.0, max_road=1.0, road_threshold=0.1
+        pace=10.0, grade=0.0, road_pace=15.0, max_foot_road=1.0, road_threshold=0.1
     )
     route, _ = challenge_planner._plan_route_greedy(
         G, trails, (0.0, 0.0), **params, dist_cache={}
@@ -323,7 +323,7 @@ def test_greedy_fallback_handles_unreachable_segment():
         pace=10.0,
         grade=0.0,
         road_pace=15.0,
-        max_road=1.0,
+        max_foot_road=1.0,
         road_threshold=0.1,
         use_rpp=False,
     )

--- a/tests/test_plan_route_tree.py
+++ b/tests/test_plan_route_tree.py
@@ -21,7 +21,7 @@ def test_tree_route_uses_trunk_twice():
         pace=10.0,
         grade=0.0,
         road_pace=10.0,
-        max_road=0.0,
+        max_foot_road=0.0,
         road_threshold=0.1,
         use_rpp=True,
     )


### PR DESCRIPTION
## Summary
- rename `--max-road` flag to `--max-foot-road`
- update config and PlannerConfig field names
- update optimizer and planner implementations
- adjust tests and documentation
- limit how far the planner will walk on roads between clusters

## Testing
- `pytest -q` *(fails: missing packages like networkx)*

------
https://chatgpt.com/codex/tasks/task_e_6850cc85e3148329833a20f45d8762c9