### PR TITLE
Improve trailhead parsing and split handling

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -3348,6 +3348,13 @@ def main(argv=None):
                 args,
                 f"split cluster into {len(connectivity_subs)} parts due to connectivity",
             )
+            if args.max_foot_road <= 0.01:
+                debug_log(
+                    args,
+                    "Connectivity split with max_foot_road too small; segments will remain unscheduled",
+                )
+                # Skip adding these segments so they appear as unscheduled later
+                continue
             for sub in connectivity_subs:
                 nodes = {pt for e in sub for pt in (e.start, e.end)}
                 processed_clusters.append((sub, nodes))

--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -202,8 +202,14 @@ def load_trailheads(path: str) -> Dict[Tuple[float, float], str]:
             reader = csv.DictReader(f)
             for row in reader:
                 try:
-                    lat = float(row.get("lat") or row.get("latitude"))
-                    lon = float(row.get("lon") or row.get("longitude"))
+                    lat_raw = row.get("lat")
+                    if lat_raw is None:
+                        lat_raw = row.get("latitude")
+                    lon_raw = row.get("lon")
+                    if lon_raw is None:
+                        lon_raw = row.get("longitude")
+                    lat = float(lat_raw)
+                    lon = float(lon_raw)
                 except (TypeError, ValueError):
                     continue
                 name = row.get("name", "")
@@ -222,8 +228,14 @@ def load_trailheads(path: str) -> Dict[Tuple[float, float], str]:
 
     for item in entries:
         try:
-            lat = float(item.get("lat") or item.get("latitude"))
-            lon = float(item.get("lon") or item.get("longitude"))
+            lat_raw = item.get("lat")
+            if lat_raw is None:
+                lat_raw = item.get("latitude")
+            lon_raw = item.get("lon")
+            if lon_raw is None:
+                lon_raw = item.get("longitude")
+            lat = float(lat_raw)
+            lon = float(lon_raw)
         except (TypeError, ValueError):
             continue
         name = item.get("name", "")


### PR DESCRIPTION
## Summary
- fix `load_trailheads` so 0-valued coordinates are read correctly
- avoid scheduling clusters split by connectivity when `max-foot-road` is very low
- ensure unscheduled segments are surfaced for unreachable clusters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c6e60dc88329a19793aefe554e93