### PR TITLE
Add strict max foot road option

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Below is a full list of command-line flags available for the challenge planner s
 * `--debug PATH` – Write per-day route rationale to the given file.
 * `--verbose` – Echo debug log messages to the console.
 * `--advanced-optimizer` – Enable the experimental multi-objective 2‑opt optimizer for reduced redundancy.
+* `--strict-max-foot-road` – Do not walk connectors longer than `--max-foot-road` (split the route instead).
 
 ## Road Connectors
 

--- a/src/trail_route_ai/optimizer.py
+++ b/src/trail_route_ai/optimizer.py
@@ -101,6 +101,7 @@ def build_route_from_order(
     road_threshold: float,
     spur_length_thresh: float = 0.3,
     spur_road_bonus: float = 0.25,
+    strict_max_foot_road: bool = False,
 ) -> List[Edge]:
     """Plan a route following ``sequence`` using the core planner."""
 
@@ -116,6 +117,7 @@ def build_route_from_order(
         ctx.dist_cache,
         spur_length_thresh=spur_length_thresh,
         spur_road_bonus=spur_road_bonus,
+        strict_max_foot_road=strict_max_foot_road,
     )
 
 
@@ -126,12 +128,19 @@ def advanced_2opt_optimization(
     required_ids: Set[str],
     max_foot_road: float,
     road_threshold: float,
+    *,
+    strict_max_foot_road: bool = False,
 ) -> Tuple[List[Edge], List[Edge]]:
     """Perform a multi-objective 2-opt optimization on ``order``."""
 
     best_order = order[:]
     best_route = build_route_from_order(
-        ctx, best_order, start, max_foot_road, road_threshold
+        ctx,
+        best_order,
+        start,
+        max_foot_road,
+        road_threshold,
+        strict_max_foot_road=strict_max_foot_road,
     )
     if not best_route:
         return [], []
@@ -150,6 +159,7 @@ def advanced_2opt_optimization(
                 start,
                 max_foot_road,
                 road_threshold,
+                strict_max_foot_road=strict_max_foot_road,
             )
             if not cand_route:
                 continue


### PR DESCRIPTION
## Summary
- rename strict road option to `strict_max_foot_road`
- propagate renamed option through planner and optimizer
- document `--strict-max-foot-road` CLI flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: networkx, gpxpy, geopandas, pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6851e253a4c08329abb88b4ff2b7e428