### PR TITLE
Fix: Periodically save APSP cache to reduce memory usage

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -3373,6 +3373,9 @@ def main(argv=None):
         # Wrap the iterator with tqdm for progress.
         # The iterator yields (source_node, dictionary_of_paths_from_source)
         # The total number of iterations for tqdm will be the number of nodes in G.
+        nodes_processed_since_last_save = 0
+        SAVE_INTERVAL = 1000  # Define save interval
+
         for source, targets in tqdm(
             apsp_iterator,
             total=num_nodes_in_g,
@@ -3380,8 +3383,18 @@ def main(argv=None):
             unit="node",
         ):
             path_cache[source] = targets
+            nodes_processed_since_last_save += 1
+            if nodes_processed_since_last_save >= SAVE_INTERVAL:
+                tqdm.write(f"APSP calculation: Saving cache to disk after processing {nodes_processed_since_last_save} nodes...")
+                cache_utils.save_cache("dist_cache", cache_key, path_cache)
+                nodes_processed_since_last_save = 0
+                tqdm.write("APSP calculation: Cache saved.")
 
         tqdm.write(f"APSP pre-computation complete. Cache populated with {len(path_cache)} entries.")
+        # Final save of the cache
+        tqdm.write("APSP calculation: Final save of cache to disk...")
+        cache_utils.save_cache("dist_cache", cache_key, path_cache)
+        tqdm.write("APSP calculation: Final cache saved.")
         # The path_cache is updated in place and will be saved later.
 
     tracking = planner_utils.load_segment_tracking(


### PR DESCRIPTION
The All-Pairs Shortest Paths (APSP) pre-computation step could consume a large amount of memory, especially when rebuilding the cache for graphs with many nodes. This could lead to the process being terminated by the system's OOM killer (resulting in a SIGKILL signal).

This change modifies the APSP calculation loop in
`src/trail_route_ai/challenge_planner.py` to save the `path_cache` to disk periodically (e.g., every 1000 nodes processed). A final save is also performed after the loop completes.

This approach aims to reduce the peak in-memory footprint of the `path_cache` during its construction, thereby mitigating the risk of OOM errors. The `UserWarning` about leaked semaphores observed in the issue is likely a symptom of the process being killed abruptly, and should be resolved if the OOM termination is prevented.