### PR TITLE
Fix: Import psutil to resolve NameError

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -26,6 +26,7 @@ from typing import Dict, List, Tuple, Set, Optional
 from trail_route_ai import cache_utils
 import logging
 import signal
+import psutil
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The `psutil` module was used without being imported, leading to a `NameError`. This commit adds the necessary import statement at the beginning of `src/trail_route_ai/challenge_planner.py`.