### PR TITLE
Fix: Add missing import for rocksdict

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import tempfile
 import shutil
+import rocksdict
 import pickle
 import hashlib
 import gc


### PR DESCRIPTION
The `rocksdict` module was used in `challenge_planner.py` without being imported, leading to a `NameError` when type hinting `dist_cache` with `rocksdict.Rdict`.

This change adds the necessary `import rocksdict` statement to resolve the error.