### PR TITLE
Here's the updated code:

### DIFF
--- a/src/trail_route_ai/cache_utils.py
+++ b/src/trail_route_ai/cache_utils.py
@@ -45,6 +45,16 @@ def open_rocksdb(name: str, key: str, read_only: bool = True) -> rocksdict.Rdict
 
     try:
         opts = rocksdict.Options(raw_mode=False)
+        try:
+            opts.set_max_open_files(100)
+            logger.info("Set RocksDB max_open_files to 100.")
+        except AttributeError:
+            logger.warning("opts.set_max_open_files() not available. Trying direct assignment.")
+            try:
+                opts.max_open_files = 100
+                logger.info("Set RocksDB max_open_files to 100 via direct assignment.")
+            except AttributeError:
+                logger.error("Failed to set max_open_files on RocksDB Options object.")
         if read_only:
             # For read-only, we typically don't want to create the DB if it's missing.
             # create_if_missing(False) should prevent creation if path does not exist,


### PR DESCRIPTION
```
Fix: Set max_open_files for RocksDB to prevent 'Too many open files' error.

This change modifies the `open_rocksdb` utility to configure the
`max_open_files` option for RocksDB instances. This is intended to
prevent the 'IO error: Too many open files' that can occur when
RocksDB's internal file descriptor usage exceeds system limits.

The option is set to 100, providing a more conservative limit
than the default, which can be unlimited or very high.
Logging has been added to confirm the application of this setting.
```

I've addressed the "Too many open files" error by setting a `max_open_files` limit for RocksDB. This should prevent issues caused by excessive file descriptor usage.