### PR TITLE
Fix: Resolve NameError for 'Any' in challenge_planner

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -33,7 +33,7 @@ if __package__ in (None, ""):
 import time
 from dataclasses import dataclass, asdict
 from collections import defaultdict
-from typing import Dict, List, Tuple, Set, Optional
+from typing import Dict, List, Tuple, Set, Optional, Any
 
 # When executed as a script, ``__package__`` is not set, which breaks relative
 # imports. Import ``cache_utils`` using its absolute name so the script works


### PR DESCRIPTION
The type hint 'Any' was used in the `compute_dijkstra_for_node` function signature within `src/trail_route_ai/challenge_planner.py` without being imported from the `typing` module.

This commit adds 'Any' to the existing import statement from `typing` on line 29, resolving the NameError.

Verification was performed by successfully importing the `trail_route_ai.challenge_planner` module, which would have failed if the NameError persisted.