### PR TITLE
Add dev requirements and clarify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Before using the planner, set up the Python environment and dependencies:
    ```bash
    python -m venv .venv  
    source .venv/bin/activate  
-   pip install -r requirements.txt  
+   pip install -r requirements.txt
+   # installs tqdm, geopandas, rasterio and other libraries
    ```
 
    This will install all required libraries as listed in `requirements.txt` (which is generated from `requirements.toml`).
@@ -50,6 +51,9 @@ system packages such as GDAL and PROJ via `apt-get` before using `pip` for the P
    ```bash
    bash run/setup.sh
    ```
+   This installs the system packages as well as all Python requirements,
+   including tqdm, geopandas, rasterio, and other dependencies needed for
+   running the tests.
 
 Once dependencies are installed, install the project in editable mode so the
 `trail_route_ai` package is available on your `PYTHONPATH`:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-timeout

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -11,33 +11,14 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     libspatialindex-dev \
     proj-bin libproj-dev
 
-# Determine path to requirements.toml relative to this script
+# Determine script directory so we can reference requirements files
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REQ_FILE="$SCRIPT_DIR/../requirements.toml"
 
-if [ ! -f "$REQ_FILE" ]; then
-  echo "Requirements file not found: $REQ_FILE" >&2
-  exit 1
+# Install Python dependencies listed in requirements.txt
+pip install -r "$SCRIPT_DIR/../requirements.txt"
+
+# Install development/testing dependencies if the file exists
+if [ -f "$SCRIPT_DIR/../requirements-dev.txt" ]; then
+  pip install -r "$SCRIPT_DIR/../requirements-dev.txt"
 fi
-
-# Parse dependencies from the TOML file using python
-packages=$(python - <<PY
-import tomllib
-import sys
-with open('$REQ_FILE', 'rb') as f:
-    data = tomllib.load(f)
-packages = data.get('python', {}).get('dependencies', [])
-print(' '.join(packages))
-PY
-)
-
-if [ -z "$packages" ]; then
-  echo "No packages found in $REQ_FILE" >&2
-  exit 1
-fi
-
-pip install $packages
-
-# Install testing utilities
-pip install pytest pytest-timeout
 


### PR DESCRIPTION
## Summary
- document installing `tqdm`, `geopandas`, `rasterio`, etc.
- add `requirements-dev.txt` with pytest deps
- simplify `run/setup.sh` to install from requirements files

## Testing
- `pip install pandas gpxpy shapely rtree networkx scikit-learn rasterio geopandas fiona numpy elevation tqdm tiktoken openai pyyaml matplotlib rocksdict psutil`
- `pytest -q` *(fails: RocksDB lock errors)*

------
https://chatgpt.com/codex/tasks/task_e_68536ca5193c8329a819a3f16d1afea8