### PR TITLE
Switch to scipy Dijkstra

### DIFF
--- a/requirements.toml
+++ b/requirements.toml
@@ -5,6 +5,7 @@ dependencies = [
   "shapely",
   "rtree",
   "networkx",
+  "scipy",
   "scikit-learn",
   "numpy",
     "rasterio",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ gpxpy
 shapely
 rtree
 networkx
+scipy
 scikit-learn
 rasterio
 geopandas


### PR DESCRIPTION
## Summary
- support using SciPy's Dijkstra via a new helper
- use the SciPy implementation when available for APSP and greedy routing
- precompute SciPy graph data on startup
- add SciPy to dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_68536cc656588329a78b1fa55f98ea03