### PR TITLE
Add log message for shortest path backend

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -3504,6 +3504,14 @@ def main(argv=None):
     root_logger.setLevel(logging.INFO if args.verbose else logging.WARNING)
     queue_handler = QueueHandler(log_queue)
     root_logger.addHandler(queue_handler)
+    if csgraph_dijkstra is not None:
+        logger.info(
+            "SciPy detected; using compiled Dijkstra implementation for routing."
+        )
+    else:
+        logger.info(
+            "SciPy not available; falling back to NetworkX for Dijkstra routing."
+        )
     # The old basicConfig is now replaced by the above setup.
     # logging.basicConfig(
     #     level=logging.INFO if args.verbose else logging.WARNING,


### PR DESCRIPTION
## Summary
- notify when SciPy Dijkstra is available or when falling back to networkx

## Testing
- `pytest -q tests/test_plan_route_greedy.py::test_simple_case -k '' -vv` *(fails: ModuleNotFoundError for networkx)*

------
https://chatgpt.com/codex/tasks/task_e_6853742b97e88329958c3f180947b8fd