### PR TITLE
Fix UnboundLocalError in planner

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -755,6 +755,7 @@ def _plan_route_greedy(
                     e_rem_name = e_rem.name or str(e_rem.seg_id)
                     reasons_for_segment = []
                     path_to_start_nodes = None
+                    path_to_end_nodes = None
 
                     # Check path to e_rem.start
                     if e_rem.start not in pred_map:


### PR DESCRIPTION
## Summary
- initialize `path_to_end_nodes` before checking possible routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68538ba279348329b204c66c3b40d405