### PR TITLE
Fix optimizer module shadowing

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -1629,14 +1629,14 @@ def plan_route(
     use_advanced_optimizer: bool = False,
     strict_max_foot_road: bool = False,
     optimizer_name: str = "greedy2opt",
-    optimizer: str | None = None,
+    optimizer_choice: str | None = None,
     postman_timeout: float = 30.0,
     postman_max_odd: int = 40,
 ) -> List[Edge]:
     """Plan an efficient loop through ``edges`` starting and ending at ``start``."""
 
-    if optimizer is not None:
-        optimizer_name = optimizer
+    if optimizer_choice is not None:
+        optimizer_name = optimizer_choice
 
     debug_log(
         debug_args,

--- a/tests/test_postman.py
+++ b/tests/test_postman.py
@@ -49,7 +49,7 @@ def test_postman_vs_greedy():
         DEFAULT_ROAD_PACE,
         0.5,
         0.1,
-        optimizer="greedy2opt",
+        optimizer_choice="greedy2opt",
     )
     len_post = sum(e.length_mi for e in r_post)
     len_greedy = sum(e.length_mi for e in r_greedy)


### PR DESCRIPTION
## Summary
- rename the optional plan_route parameter to avoid shadowing the optimizer module
- adjust test call accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68538df41eac83298816a3b722dee565