### PR TITLE
Handle unscheduled segments without raising error

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -4900,7 +4900,10 @@ def main(argv=None):
             )
             # Optionally, log to debug log as well
             debug_log(args, error_message)
-            raise ValueError(error_message)
+            # Mark routing as failed and continue so outputs are written with the
+            # "failed-" prefix instead of raising an exception.
+            overall_routing_status_ok = False
+            tqdm.write(error_message, file=sys.stderr)
 
     export_plan_files(
         daily_plans,


### PR DESCRIPTION
## Summary
- avoid raising ValueError when segments remain unscheduled
- mark plan as failed and still output files
- adjust unit tests to expect failed output rather than an exception

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6853fe47e41c832986a8104be7e1dbba