### PR TITLE
Fix advanced optimizer access

### DIFF
--- a/src/trail_route_ai/__init__.py
+++ b/src/trail_route_ai/__init__.py
@@ -9,8 +9,8 @@ from .planner_utils import (
 from .optimizer import (
     RouteMetrics,
     is_pareto_improvement,
-    advanced_2opt_optimization,
 )
+from .challenge_planner import advanced_2opt_optimization
 from .postman import solve_rpp
 from . import cache_utils
 

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -1607,6 +1607,28 @@ def _plan_route_tree(edges: List[Edge], start: Tuple[float, float]) -> List[Edge
     return route
 
 
+def advanced_2opt_optimization(
+    ctx: planner_utils.PlanningContext,
+    order: List[Edge],
+    start: Tuple[float, float],
+    required_ids: Set[str],
+    max_foot_road: float,
+    road_threshold: float,
+    *,
+    strict_max_foot_road: bool = False,
+) -> Tuple[List[Edge], List[Edge]]:
+    """Delegate to :func:`trail_route_ai.optimizer.advanced_2opt_optimization`."""
+
+    return optimizer.advanced_2opt_optimization(
+        ctx,
+        order,
+        start,
+        required_ids,
+        max_foot_road,
+        road_threshold,
+        strict_max_foot_road=strict_max_foot_road,
+    )
+
 def plan_route(
     G: nx.DiGraph,
     edges: List[Edge],


### PR DESCRIPTION
## Summary
- expose advanced_2opt_optimization from challenge_planner
- update package exports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_68540618af548329819bc91d42b25bcf