### PR TITLE
Add per-day draft output feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Below is a full list of command-line flags available for the challenge planner s
 * `--optimizer {greedy2opt,postman}` – Choose the routing optimizer. `postman` may yield shorter loops but can take longer.
 * `--postman-timeout FLOAT` – Time limit in seconds for the postman optimizer (default 30).
 * `--postman-max-odd INT` – Abort the postman step if the number of odd-degree nodes exceeds this (default 40).
+* `--draft-daily` – Write draft CSV/HTML outputs after each day in a `draft_plans/` folder.
 * `--strict-max-foot-road` – Do not walk connectors longer than `--max-foot-road` (split the route instead).
 
 ## Road Connectors

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -417,6 +417,7 @@ class PlannerConfig:
     optimizer: str = "greedy2opt"
     postman_timeout: float = 30.0
     postman_max_odd: int = 40
+    draft_daily: bool = False
 
 
 def load_config(path: str) -> PlannerConfig:
@@ -3601,6 +3602,12 @@ def main(argv=None):
         help="Write draft CSV and HTML files every N days",
     )
     parser.add_argument(
+        "--draft-daily",
+        action="store_true",
+        default=config_defaults.get("draft_daily", False),
+        help="Write draft outputs after each day into draft_plans/",
+    )
+    parser.add_argument(
         "--strict-max-foot-road",
         action="store_true",
         default=config_defaults.get("strict_max_foot_road", False),
@@ -4779,6 +4786,22 @@ def main(argv=None):
                 review=False,
                 challenge_ids=current_challenge_segment_ids,
             )
+
+        if args.draft_daily:
+            draft_dir = os.path.join(os.path.dirname(args.output), "draft_plans")
+            os.makedirs(draft_dir, exist_ok=True)
+            draft_csv = os.path.join(draft_dir, f"draft-day{day_idx+1}.csv")
+            orig_gpx_dir = args.gpx_dir
+            args.gpx_dir = os.path.join(draft_dir, f"gpx_day{day_idx+1}")
+            export_plan_files(
+                daily_plans,
+                args,
+                csv_path=draft_csv,
+                write_gpx=True,
+                review=False,
+                challenge_ids=current_challenge_segment_ids,
+            )
+            args.gpx_dir = orig_gpx_dir
 
     # Smooth the schedule if we have lightly used days and remaining clusters
     segments_in_unplanned_before_smooth = set()


### PR DESCRIPTION
## Summary
- allow writing draft outputs after each planning day via `--draft-daily`
- document `--draft-daily` in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6854149b745c8329bec1e16b97c8ec89