### PR TITLE
Add connector trail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ python -m trail_route_ai.challenge_planner --start-date 2024-07-01 --end-date 20
     --advanced-optimizer --debug debug --verbose
 ```
 
+If you have the full Boise trail network data available, you can also provide
+`--connector-trails data/traildata/Boise_Parks_Trails_Open_Data.geojson` so the
+planner can use additional non-challenge trails to connect official segments
+and return to the trailhead more efficiently.
+
 In this example, the `--dem` option is pointed to a digital elevation model file so the planner can calculate elevation gain for each segment (improving the accuracy of time estimates and enabling elevation profile output). The `--year 2024` flag tells the planner to ignore any segment completions not from 2024, so it plans all segments for the current year’s challenge by default.
 
 After running the planner, check the output directory for results. By default, the planner will produce:
@@ -375,6 +380,7 @@ Below is a full list of command-line flags available for the challenge planner s
 * `--pace FLOAT` – Base running pace in minutes per mile.
 * `--grade FLOAT` – Additional seconds per 100 ft of elevation gain (to account for climbing effort; default 0).
 * `--segments PATH` – Path to the trail segment definitions file (defaults to `data/traildata/trail.json`).
+* `--connector-trails PATH` – Supplemental trail network GeoJSON for connector segments (default `data/traildata/Boise_Parks_Trails_Open_Data.geojson`).
 * `--dem PATH` – Path to a digital elevation model (GeoTIFF) for computing elevation gain (optional but recommended for accurate stats).
 * `--roads PATH` – Path to a road network file (GeoJSON or OSM PBF) to enable road connectors (optional).
 * `--trailheads PATH` – Path to a trailheads file (JSON or CSV) if you have custom trailhead locations to consider (optional).


### PR DESCRIPTION
## Summary
- support `--connector-trails` option for loading extra trail data
- document connector trail option in README
- test that the CLI loads connector trail files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib', NameError: path_back_penalty)*

------
https://chatgpt.com/codex/tasks/task_e_6854b72e0e588329acf5bbf575d3ff7a