### PR TITLE
Fix connector trails option

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Below is a full list of command-line flags available for the challenge planner s
 * `--pace FLOAT` – Base running pace in minutes per mile.
 * `--grade FLOAT` – Additional seconds per 100 ft of elevation gain (to account for climbing effort; default 0).
 * `--segments PATH` – Path to the trail segment definitions file (defaults to `data/traildata/trail.json`).
-* `--connector-trails PATH` – Supplemental trail network GeoJSON for connector segments (default `data/traildata/Boise_Parks_Trails_Open_Data.geojson`).
+* `--connector-trails PATH` – Supplemental trail network GeoJSON for connector segments (optional; no default file is assumed).
 * `--dem PATH` – Path to a digital elevation model (GeoTIFF) for computing elevation gain (optional but recommended for accurate stats).
 * `--roads PATH` – Path to a road network file (GeoJSON or OSM PBF) to enable road connectors (optional).
 * `--trailheads PATH` – Path to a trailheads file (JSON or CSV) if you have custom trailhead locations to consider (optional).

--- a/config/planner_config.json
+++ b/config/planner_config.json
@@ -24,6 +24,7 @@
   "roads": null,
   "rpp_timeout": 5.0,
   "segments": "data/traildata/trail.json",
+  "connector_trails": null,
   "spur_length_thresh": 0.3,
   "spur_road_bonus": 0.25,
   "start_date": "2025-06-19",

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -416,7 +416,7 @@ class PlannerConfig:
     pace: Optional[float] = None
     grade: float = 0.0
     segments: str = "data/traildata/trail.json"
-    connector_trails: Optional[str] = None
+    connector_trails: Optional[str] = None  # Supplemental trail network; unused if None
     dem: Optional[str] = None
     roads: Optional[str] = None
     trailheads: Optional[str] = None
@@ -3579,7 +3579,7 @@ def main(argv=None):
         "--connector-trails",
         dest="connector_trails",
         default=config_defaults.get("connector_trails"),
-        help="Additional trail network GeoJSON for connector trails",
+        help="Additional trail network GeoJSON for connector trails (none used if omitted)",
     )
     parser.add_argument(
         "--dem",


### PR DESCRIPTION
## Summary
- clarify that connector trails file is optional
- mention optional connector trails in argument parser
- list connector_trails as null in planner_config.json

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68558b505998832994d6d13367032fc4