### PR TITLE
Fix dev requirements include runtime deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,10 @@ This currently downloads the latest OpenStreetMap data for Idaho (`idaho-latest.
 
 ## Running Tests
 
-If you want to run the test suite (for development purposes), install the runtime dependencies and `pytest`:
+If you want to run the test suite (for development purposes), install the development requirements which pull in the runtime dependencies as well:
 
 ```bash
-pip install -r requirements.txt
-pip install pytest
+pip install -r requirements-dev.txt
 pytest -q
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,5 @@
+# Development dependencies
+# Include the main requirements so tests have all runtime packages
+-r requirements.txt
 pytest
 pytest-timeout


### PR DESCRIPTION
## Summary
- ensure dev requirements install runtime packages
- clarify README test instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_68558f2924c48329aea2c801d78e86ca