### PR TITLE
Add trail-road foot connectors

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -4035,9 +4035,20 @@ def main(argv=None):
     if args.trailheads and os.path.exists(args.trailheads):
         trailhead_lookup = planner_utils.load_trailheads(args.trailheads)
 
+    # Add short connectors from trail ends to nearby road nodes for better
+    # on-foot routing connectivity.
+    foot_connectors = planner_utils.connect_trails_to_roads(
+        all_trail_segments + connector_trail_segments,
+        all_road_segments,
+        threshold_meters=50.0,
+    )
+
     # This graph is used for on-foot routing *within* macro-clusters
     on_foot_routing_graph_edges = (
-        all_trail_segments + connector_trail_segments + all_road_segments
+        all_trail_segments
+        + connector_trail_segments
+        + all_road_segments
+        + foot_connectors
     )
     G = build_nx_graph(
         on_foot_routing_graph_edges, args.pace, args.grade, args.road_pace

--- a/tests/test_planner_utils_extra.py
+++ b/tests/test_planner_utils_extra.py
@@ -123,3 +123,35 @@ def test_load_segments_multilinestring(tmp_path):
     assert edges[0].end == (1, 0)
     assert edges[1].start == (1, 0)
     assert edges[1].end == (1, 1)
+
+
+def test_connect_trails_to_roads():
+    trail = planner_utils.Edge(
+        "T",
+        "T",
+        (0.0, 0.0),
+        (0.001, 0.0),
+        0.1,
+        0.0,
+        [(0.0, 0.0), (0.001, 0.0)],
+        "trail",
+        "both",
+    )
+    road = planner_utils.Edge(
+        "R",
+        "R",
+        (0.0004, 0.0),
+        (0.0004, 0.001),
+        0.1,
+        0.0,
+        [(0.0004, 0.0), (0.0004, 0.001)],
+        "road",
+        "both",
+    )
+
+    connectors = planner_utils.connect_trails_to_roads([trail], [road], threshold_meters=50.0)
+    assert connectors
+    c = connectors[0]
+    assert c.kind == "road"
+    assert c.start in {trail.start, trail.end}
+    assert c.end in {road.start, road.end}


### PR DESCRIPTION
## Summary
- connect trail ends to nearby road nodes for better routing
- use connectors when building the routing graph
- test helper for connecting trails to roads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_6855916c88a0832983560e8c9d630733