### PR TITLE
Fix unused imports

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -5,14 +5,12 @@ import sys
 import os  # Ensure os is imported for path operations
 import datetime
 import json
-import tempfile
 import shutil
 import rocksdict
 import pickle
 import hashlib
 import gc
 import multiprocessing
-import functools
 
 # Ensure psutil is imported (it is)
 # Ensure signal is imported (it is)


### PR DESCRIPTION
## Summary
- remove unused tempfile and functools imports

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib', ModuleNotFoundError: No module named 'openai', ModuleNotFoundError: No module named 'tiktoken', AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68559b563d48832995290d73249d1070