### PR TITLE
Remove obsolete file-based cache utils

### DIFF
--- a/src/trail_route_ai/cache_utils.py
+++ b/src/trail_route_ai/cache_utils.py
@@ -31,11 +31,6 @@ def get_cache_dir() -> str:
     return path
 
 
-def _cache_path(name: str, key: str) -> str:
-    h = hashlib.sha1(key.encode()).hexdigest()[:16]
-    return os.path.join(get_cache_dir(), f"{name}_{h}.pkl")
-
-
 def _rocksdb_path(name: str, key: str) -> str:
     h = hashlib.sha1(key.encode()).hexdigest()[:16]
     return os.path.join(get_cache_dir(), f"{name}_{h}_db")
@@ -122,31 +117,7 @@ def save_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any, da
         # logger.info(f"Saved to RocksDB cache for source_node: {source_node}") # Becomes too verbose
     except Exception as e:
         # logger.error(f"Failed to save to RocksDB for source_node {source_node}: {e}") # Becomes too verbose
-        pass # Fail silently like the original save_cache
-
-
-def load_cache(name: str, key: str) -> Any | None:
-    path = _cache_path(name, key)
-    if os.path.exists(path):
-        try:
-            with open(path, "rb") as f:
-                data = pickle.load(f)
-            logger.info("Loaded cache %s:%s", name, key)
-            return data
-        except Exception:
-            return None
-    return None
-
-
-def save_cache(name: str, key: str, data: Any) -> None:
-    path = _cache_path(name, key)
-    try:
-        with open(path, "wb") as f:
-            pickle.dump(data, f)
-        logger.info("Saved cache %s:%s", name, key)
-    except Exception:
-        pass
-
+        pass  # Fail silently
 
 def clear_cache() -> None:
     dir_path = get_cache_dir()

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -4115,8 +4115,6 @@ def main(argv=None):
     )
 
     cache_key = f"{args.pace}:{args.grade}:{args.road_pace}"
-    # path_cache: dict | None = cache_utils.load_cache("dist_cache", cache_key) or {} # Old pickle cache
-    # logger.info("Loaded path cache with %d start nodes", len(path_cache)) # Old pickle cache
 
     path_cache_db_instance = None  # Will be RocksDB instance
 
@@ -5324,9 +5322,6 @@ def main(argv=None):
         challenge_ids=current_challenge_segment_ids,
         routing_failed=not overall_routing_status_ok,
     )
-
-    # cache_utils.save_cache("dist_cache", cache_key, path_cache) # Old pickle cache save
-    # logger.info("Saved path cache with %d start nodes", len(path_cache)) # Old pickle cache log
 
     # Stop the listener and clear the queue at the end of main
     # It's important to handle the queue properly, though for daemon processes

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -3,19 +3,6 @@ import hashlib
 from trail_route_ai import cache_utils
 
 
-def test_cache_roundtrip(tmp_path, monkeypatch):
-    monkeypatch.setenv("BTAI_CACHE_DIR", str(tmp_path))
-    cache_utils.clear_cache()
-    data = {"foo": 1}
-    cache_utils.save_cache("dist", "key", data)
-    cache_file = tmp_path / f"dist_{hashlib.sha1('key'.encode()).hexdigest()[:16]}.pkl"
-    assert cache_file.exists()
-    loaded = cache_utils.load_cache("dist", "key")
-    assert loaded == data
-    cache_utils.clear_cache()
-    assert not tmp_path.exists()
-
-
 import unittest
 import shutil
 import rocksdict


### PR DESCRIPTION
## Summary
- drop `load_cache` and `save_cache` utilities
- clean up old pickle cache comments
- update cache utils tests

## Testing
- `pytest tests/test_cache_utils.py::TestCacheUtilsRocksDB::test_open_rocksdb_read_only_non_existent -q`

------
https://chatgpt.com/codex/tasks/task_e_68559b3ff7cc832993498a831459b468