### PR TITLE
Fix some flake8 issues

### DIFF
--- a/clip_pbf.py
+++ b/clip_pbf.py
@@ -36,7 +36,9 @@ def clip_pbf(
     try:
         subprocess.run(cmd, check=True)
     except FileNotFoundError as exc:
-        raise RuntimeError("osmium command not found; install osmium-tool") from exc
+        raise RuntimeError(
+            "osmium command not found; install osmium-tool"
+        ) from exc
 
     size_mb = out_path.stat().st_size / 1e6
     print(f"Clipped OSM saved: {size_mb:.1f} MB -> {out_path}")
@@ -46,7 +48,9 @@ def clip_pbf(
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pbf", required=True, help="Input OSM PBF file")
-    parser.add_argument("--trails", required=True, help="Trail GeoJSON defining area")
+    parser.add_argument(
+        "--trails", required=True, help="Trail GeoJSON defining area"
+    )
     parser.add_argument(
         "--out", default="osm_boise_clipped.pbf", help="Output PBF path"
     )

--- a/clip_srtm.py
+++ b/clip_srtm.py
@@ -5,14 +5,15 @@ import argparse
 from pathlib import Path
 
 import geopandas as gpd
-from shapely.ops import unary_union
 import elevation
 import rasterio
 from rasterio.mask import mask
 
 
 def clip_srtm(
-    trails_path: str, out_path: str = "srtm_boise_clipped.tif", buffer_km: float = 3.0
+    trails_path: str,
+    out_path: str = "srtm_boise_clipped.tif",
+    buffer_km: float = 3.0,
 ) -> Path:
     """Download SRTM tiles touching the buffered trails and clip them."""
     # use Fiona engine for better driver support on some systems
@@ -26,7 +27,6 @@ def clip_srtm(
     maxy += deg
     from shapely.geometry import box
 
-    bbox = (minx, miny, maxx, maxy)
     area = box(minx, miny, maxx, maxy)
 
     out_path = Path(out_path).resolve()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,11 @@ here = pathlib.Path(__file__).parent
 # Read requirements from requirements.txt
 req_file = here / "requirements.txt"
 with req_file.open() as f:
-    requirements = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+    requirements = [
+        line.strip()
+        for line in f
+        if line.strip() and not line.startswith('#')
+    ]
 
 setup(
     name="boise-trails-ai",

--- a/src/trail_route_ai/cache_utils.py
+++ b/src/trail_route_ai/cache_utils.py
@@ -41,8 +41,11 @@ def open_rocksdb(name: str, key: str, read_only: bool = True) -> rocksdict.Rdict
     # Ensure parent directory of the cache store exists
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
-    if read_only and not os.path.exists(path): # If read-only and DB dir doesn't exist, don't even try to open
-        logger.info(f"RocksDB at {path} not found for read-only access. Path does not exist.")
+    if read_only and not os.path.exists(path):
+        # If read-only and DB dir doesn't exist, don't even try to open
+        logger.info(
+            f"RocksDB at {path} not found for read-only access. Path does not exist."
+        )
         return None
 
     try:
@@ -85,8 +88,8 @@ def close_rocksdb(db: rocksdict.Rdict | None) -> None:
     if db is not None:
         try:
             db.close()
-        except Exception as e:
-            logger.error(f"Failed to close RocksDB: {e}")
+        except Exception:
+            logger.error("Failed to close RocksDB")
 
 
 def load_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any) -> Any | None:
@@ -101,8 +104,8 @@ def load_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any) ->
             # logger.info(f"Loaded from RocksDB cache for source_node: {source_node}") # Becomes too verbose
             return data
         return None
-    except Exception as e:
-        # logger.error(f"Failed to load from RocksDB for source_node {source_node}: {e}") # Becomes too verbose
+    except Exception:
+        # logger.error("Failed to load from RocksDB for source_node %s: %s", source_node, e)
         return None
 
 
@@ -115,9 +118,10 @@ def save_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any, da
         value_bytes = pickle.dumps(data)
         db_instance[key_bytes] = value_bytes
         # logger.info(f"Saved to RocksDB cache for source_node: {source_node}") # Becomes too verbose
-    except Exception as e:
-        # logger.error(f"Failed to save to RocksDB for source_node {source_node}: {e}") # Becomes too verbose
+    except Exception:
+        # logger.error("Failed to save to RocksDB for source_node %s", source_node)
         pass  # Fail silently
+
 
 def clear_cache() -> None:
     dir_path = get_cache_dir()


### PR DESCRIPTION
## Summary
- address minor flake8 warnings in CLI utilities
- reformat requirements loading in setup script
- tweak cache util exception handling and comments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6855a051a7b4832981442a08b78e57e7