### PR TITLE
Hide short road edges in plan HTML

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -2745,6 +2745,9 @@ def write_plan_html(
             lines.append(f"<h3>Part {part_idx}: {act.get('start_name','Route')}</h3>")
             lines.append("<ul>")
             for e in act.get("route_edges", []):
+                # Skip tiny road connectors to reduce clutter in the HTML
+                if e.kind == "road" and e.length_mi < 0.05:
+                    continue
                 seg_name = e.name or str(e.seg_id)
                 direction_note = f" ({e.direction})" if e.direction != "both" else ""
                 lines.append(


### PR DESCRIPTION
## Summary
- filter very short road segments when generating the HTML plan

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6855a9861bac83298b21d4277e25bcb6