### PR TITLE
Fix setup for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ openai
 pyyaml
 matplotlib
 rocksdict
+psutil

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -15,10 +15,15 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Install Python dependencies listed in requirements.txt
-pip install -r "$SCRIPT_DIR/../requirements.txt"
+# pyrosm currently lacks wheels for Python 3.12 and is expensive to
+# build from source. The tests don't depend on it, so skip installing
+# pyrosm to keep setup fast.
+grep -v '^pyrosm' "$SCRIPT_DIR/../requirements.txt" > /tmp/requirements.txt
+pip install -r /tmp/requirements.txt
 
 # Install development/testing dependencies if the file exists
 if [ -f "$SCRIPT_DIR/../requirements-dev.txt" ]; then
-  pip install -r "$SCRIPT_DIR/../requirements-dev.txt"
+  sed '/^-r requirements.txt$/d' "$SCRIPT_DIR/../requirements-dev.txt" > /tmp/requirements-dev.txt
+  pip install -r /tmp/requirements-dev.txt
 fi
 


### PR DESCRIPTION
## Summary
- streamline setup.sh to skip heavy pyrosm install
- keep dev requirements from reinstalling pyrosm
- include `psutil` package so tests can import it

## Testing
- `bash run/setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b82ee018832994e8f5575576a1c8