### PR TITLE
Add junction labels to turn-by-turn directions

### DIFF
--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -850,8 +850,27 @@ def generate_turn_by_turn(
         name = e.name or str(e.seg_id)
         dir_note = f" ({e.direction})" if e.direction != "both" else ""
         turn = compute_turn_direction(prev, e)
+
+        junction_note = ""
+        if (
+            challenge_ids
+            and prev.seg_id is not None
+            and e.seg_id is not None
+            and str(prev.seg_id) in challenge_ids
+            and str(e.seg_id) in challenge_ids
+            and _close(prev.end_actual, e.start_actual)
+        ):
+            jname = f"Junction ({prev.name} × {e.name})"
+            junction_note = f" at {jname}"
+
+        keep_note = ""
+        if e.direction.lower() in {"ascent", "uphill"}:
+            keep_note = " – keep uphill"
+        elif e.direction.lower() in {"descent", "downhill"}:
+            keep_note = " – keep downhill"
+
         lines.append(
-            f"Turn {turn} onto {name}{dir_note} ({_path_type(e)}) for {e.length_mi:.1f} mi"
+            f"Turn {turn}{junction_note} onto {name}{dir_note} ({_path_type(e)}) for {e.length_mi:.1f} mi{keep_note}"
         )
         prev = e
 

--- a/tests/test_turn_by_turn.py
+++ b/tests/test_turn_by_turn.py
@@ -1,0 +1,38 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location(
+    "planner_utils",
+    pathlib.Path(__file__).resolve().parents[1] / "src" / "trail_route_ai" / "planner_utils.py",
+)
+planner_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(planner_utils)
+
+
+def test_turn_by_turn_with_junction():
+    e1 = planner_utils.Edge(
+        "1",
+        "Kestral",
+        (0.0, 0.0),
+        (1.0, 0.0),
+        1.0,
+        0.0,
+        [(0.0, 0.0), (1.0, 0.0)],
+        "trail",
+        "both",
+    )
+    e2 = planner_utils.Edge(
+        "2",
+        "Red Cliffs",
+        (1.0, 0.0),
+        (1.0, 1.0),
+        1.0,
+        0.0,
+        [(1.0, 0.0), (1.0, 1.0)],
+        "trail",
+        "ascent",
+    )
+
+    lines = planner_utils.generate_turn_by_turn([e1, e2], {"1", "2"})
+    assert any("Junction" in l for l in lines[1:])
+    assert "keep uphill" in lines[1]


### PR DESCRIPTION
## Summary
- label junctions when generating turn‑by‑turn directions
- test junction labeling logic

## Testing
- `pytest tests/test_turn_by_turn.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6855cda8a32083298aca57183f919355