### PR TITLE
Remove zero-length road segments from reports

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -3124,12 +3124,13 @@ def export_plan_files(
             if activity_or_drive["type"] == "activity":
                 num_activities_this_day += 1
                 route = activity_or_drive["route_edges"]
+                route_filtered = planner_utils.prune_short_connectors(route)
                 activity_name = activity_or_drive["name"]
 
-                dist = sum(e.length_mi for e in route)
-                gain = sum(e.elev_gain_ft for e in route)
+                dist = sum(e.length_mi for e in route_filtered)
+                gain = sum(e.elev_gain_ft for e in route_filtered)
                 est_activity_time = total_time(
-                    route, args.pace, args.grade, args.road_pace
+                    route_filtered, args.pace, args.grade, args.road_pace
                 )
                 activity_or_drive["stats"] = {
                     "distance_mi": dist,
@@ -3137,15 +3138,15 @@ def export_plan_files(
                     "time_min": est_activity_time,
                 }
                 activity_or_drive["directions"] = planner_utils.generate_turn_by_turn(
-                    route, challenge_ids
+                    route_filtered, challenge_ids
                 )
                 activity_or_drive["inefficiencies"] = (
-                    planner_utils.detect_inefficiencies(route)
+                    planner_utils.detect_inefficiencies(route_filtered)
                 )
 
                 current_day_total_trail_distance += dist
                 current_day_total_trail_gain += gain
-                for e in route:
+                for e in route_filtered:
                     if (
                         e.kind == "trail"
                         and e.seg_id is not None
@@ -3162,7 +3163,7 @@ def export_plan_files(
                     gpx_path = os.path.join(current_gpx_dir, gpx_file_name)
                     planner_utils.write_gpx(
                         gpx_path,
-                        route,
+                        route_filtered,
                         mark_road_transitions=args.mark_road_transitions,
                         start_name=activity_or_drive.get("start_name"),
                     )

--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -874,6 +874,23 @@ def detect_inefficiencies(edges: List[Edge]) -> List[str]:
     return sorted(set(flags))
 
 
+def prune_short_connectors(
+    edges: List[Edge], threshold_mi: float = 0.01
+) -> List[Edge]:
+    """Return ``edges`` with tiny road/connector segments removed."""
+
+    pruned: List[Edge] = []
+    for e in edges:
+        kind = e.kind or ""
+        if (
+            e.length_mi < threshold_mi
+            and (kind in {"road", "foot_connector", "connector"} or e.name == "foot_connector")
+        ):
+            continue
+        pruned.append(e)
+    return pruned
+
+
 def estimate_drive_time_minutes(
     start_coord: Tuple[float, float],
     end_coord: Tuple[float, float],


### PR DESCRIPTION
## Summary
- filter out tiny road and connector segments when exporting routes
- expose helper `prune_short_connectors` for this filter
- ensure outputs use the pruned route edges

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cd807a808329b866dd1dcb6c7ce7