### PR TITLE
Add drive mode styling and parking header

### DIFF
--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -824,8 +824,10 @@ def compute_turn_direction(prev: Edge, nxt: Edge) -> str:
 
 def generate_turn_by_turn(
     edges: List[Edge], challenge_ids: Optional[Set[str]] = None
-) -> List[str]:
-    """Return human-readable turn-by-turn directions for ``edges``."""
+) -> List[Dict[str, str]]:
+    """Return human-readable turn-by-turn directions for ``edges``.
+
+    Each returned item is a ``{"text": str, "mode": "foot"}`` dict."""
 
     if not edges:
         return []
@@ -837,12 +839,15 @@ def generate_turn_by_turn(
             return "official trail"
         return "connector trail"
 
-    lines: List[str] = []
+    lines: List[Dict[str, str]] = []
     first = edges[0]
     name = first.name or str(first.seg_id)
     dir_note = f" ({first.direction})" if first.direction != "both" else ""
     lines.append(
-        f"Start on {name}{dir_note} ({_path_type(first)}) for {first.length_mi:.1f} mi"
+        {
+            "text": f"Start on {name}{dir_note} ({_path_type(first)}) for {first.length_mi:.1f} mi",
+            "mode": "foot",
+        }
     )
 
     prev = first
@@ -870,7 +875,10 @@ def generate_turn_by_turn(
             keep_note = " – keep downhill"
 
         lines.append(
-            f"Turn {turn}{junction_note} onto {name}{dir_note} ({_path_type(e)}) for {e.length_mi:.1f} mi{keep_note}"
+            {
+                "text": f"Turn {turn}{junction_note} onto {name}{dir_note} ({_path_type(e)}) for {e.length_mi:.1f} mi{keep_note}",
+                "mode": "foot",
+            }
         )
         prev = e
 

--- a/tests/test_turn_by_turn.py
+++ b/tests/test_turn_by_turn.py
@@ -34,5 +34,5 @@ def test_turn_by_turn_with_junction():
     )
 
     lines = planner_utils.generate_turn_by_turn([e1, e2], {"1", "2"})
-    assert any("Junction" in l for l in lines[1:])
-    assert "keep uphill" in lines[1]
+    assert any("Junction" in l["text"] for l in lines[1:])
+    assert "keep uphill" in lines[1]["text"]


### PR DESCRIPTION
## Summary
- include a `mode` field in each planned activity for drive vs foot
- return turn-by-turn directions as dicts with a mode
- show driving legs with a car icon in HTML output
- add parking header before each hiking part
- adjust tests for new turn-by-turn format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6855d159d8308329a2e056f093477c0a