### PR TITLE
Filter tiny edges from directions

### DIFF
--- a/tests/test_turn_by_turn.py
+++ b/tests/test_turn_by_turn.py
@@ -36,3 +36,46 @@ def test_turn_by_turn_with_junction():
     lines = planner_utils.generate_turn_by_turn([e1, e2], {"1", "2"})
     assert any("Junction" in l["text"] for l in lines[1:])
     assert "keep uphill" in lines[1]["text"]
+
+
+def test_turn_by_turn_filters_zero_length_and_formats():
+    e1 = planner_utils.Edge(
+        "1",
+        "A",
+        (0.0, 0.0),
+        (1.0, 0.0),
+        1.0,
+        0.0,
+        [(0.0, 0.0), (1.0, 0.0)],
+        "trail",
+        "both",
+    )
+    e_small = planner_utils.Edge(
+        None,
+        "road",
+        (1.0, 0.0),
+        (1.0, 0.00001),
+        0.0001,
+        0.0,
+        [(1.0, 0.0), (1.0, 0.00001)],
+        "road",
+        "both",
+    )
+    e2 = planner_utils.Edge(
+        "2",
+        "B",
+        (1.0, 0.00001),
+        (2.0, 0.00001),
+        0.015,
+        0.0,
+        [(1.0, 0.00001), (2.0, 0.00001)],
+        "trail",
+        "both",
+    )
+
+    lines = planner_utils.generate_turn_by_turn([e1, e_small, e2])
+    # The near-zero road segment should be dropped
+    assert len(lines) == 2
+    assert lines[0]["text"].startswith("Start on A")
+    # Ensure small distances use two decimal places (0.015 -> 0.02)
+    assert "0.02 mi" in lines[1]["text"]


### PR DESCRIPTION
## Summary
- clean up turn-by-turn direction generation
- filter tiny connector edges and format short mileage with two decimals
- test removal of zero-length steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rocksdict')*

------
https://chatgpt.com/codex/tasks/task_e_6855da00542883299a8a69e7352ee2af