### PR TITLE
Improve turn-by-turn output

### DIFF
--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -860,6 +860,7 @@ def generate_turn_by_turn(
     )
 
     prev = first_end
+    prev_name = name
     for group, e_start, e_end in grouped[1:]:
         group_len = sum(e.length_mi for e in group)
         name = e_start.name or str(e_start.seg_id)
@@ -889,13 +890,17 @@ def generate_turn_by_turn(
         elif e_start.direction.lower() in {"descent", "downhill"}:
             keep_note = " – keep downhill"
 
-        lines.append(
-            {
-                "text": f"Turn {turn}{junction_note} onto {name}{dir_note}{extra} ({_path_type(e_start)}) for {group_len:.1f} mi{keep_note}",
-                "mode": "foot",
-            }
-        )
+        if not (
+            group_len < 0.1 and name == prev_name
+        ):
+            lines.append(
+                {
+                    "text": f"Turn {turn}{junction_note} onto {name}{dir_note}{extra} ({_path_type(e_start)}) for {group_len:.1f} mi{keep_note}",
+                    "mode": "foot",
+                }
+            )
         prev = e_end
+        prev_name = name
 
     return lines
 


### PR DESCRIPTION
## Summary
- suppress directions for repeated short segments on the same trail

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6855df1813948329b3589e37cf7c1f1b