### PR TITLE
Implement export skip on routing failure

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -5553,12 +5553,18 @@ def main(argv=None):
             overall_routing_status_ok = False
             tqdm.write(error_message, file=sys.stderr)
 
-    export_plan_files(
-        daily_plans,
-        args,
-        challenge_ids=current_challenge_segment_ids,
-        routing_failed=not overall_routing_status_ok,
-    )
+    if overall_routing_status_ok:
+        export_plan_files(
+            daily_plans,
+            args,
+            challenge_ids=current_challenge_segment_ids,
+            routing_failed=not overall_routing_status_ok,
+        )
+    else:
+        tqdm.write(
+            "Routing errors detected. Resolve them before exporting the plan.",
+            file=sys.stderr,
+        )
 
     # Stop the listener and clear the queue at the end of main
     # It's important to handle the queue properly, though for daemon processes

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -187,7 +187,7 @@ def test_failed_output_for_unscheduled_segment(tmp_path):
     with patch('trail_route_ai.plan_review.review_plan'):
         challenge_planner.main(args_list)
 
-    assert failed_csv.exists()
+    assert not failed_csv.exists()
 
 
 def test_failed_output_for_unroutable_segment_if_forced(tmp_path, monkeypatch):
@@ -220,7 +220,7 @@ def test_failed_output_for_unroutable_segment_if_forced(tmp_path, monkeypatch):
         with patch('trail_route_ai.plan_review.review_plan'):
             challenge_planner.main(args_list)
 
-    assert failed_csv.exists()
+    assert not failed_csv.exists()
 
 
 # --- Keep existing tests below ---
@@ -443,7 +443,7 @@ def test_daily_hours_file(tmp_path):
     with patch('trail_route_ai.plan_review.review_plan'):
         challenge_planner.main(args_list)
 
-    assert failed_csv.exists()
+    assert not failed_csv.exists()
 
 
 def test_trailhead_start_in_output(tmp_path):
@@ -542,10 +542,11 @@ def test_infeasible_plan_detection_message(tmp_path, capsys):
         with patch('trail_route_ai.plan_review.review_plan'):
             challenge_planner.main(args_list)
     captured = capsys.readouterr()
-    assert failed_csv.exists()
+    assert not failed_csv.exists()
     assert "impossible to complete all trails" in captured.err
     assert "Failed to schedule" in captured.err
     assert "Unroutable" in captured.err
+    assert "Resolve them before exporting" in captured.err
 
 
 def test_unrouteable_cluster_split(tmp_path): # Simplified, focus on planner output

--- a/tests/test_virtual_node_connectors.py
+++ b/tests/test_virtual_node_connectors.py
@@ -29,5 +29,8 @@ def test_missing_official_nodes_added(monkeypatch):
     assert extra_node in G.nodes
     outgoing = list(G.edges(extra_node, data=True))
     assert outgoing, "virtual connector not created"
-    assert any(d["edge"].kind == "virtual" and pytest.approx(d["weight"], 0.1) for _, _, d in outgoing)
+    assert any(
+        d["edge"].kind == "virtual" and d["weight"] == pytest.approx(0.1)
+        for _, _, d in outgoing
+    )
 


### PR DESCRIPTION
## Summary
- avoid exporting plan files when routing errors occur
- test for message when routing fails and adjust assertions
- fix approx usage in virtual node connectors test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561f1cad708329a4d1e3fabcfa064c