### PR TITLE
Handle failed routing in planner

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -5557,6 +5557,12 @@ def main(argv=None):
             # "failed-" prefix instead of raising an exception.
             overall_routing_status_ok = False
             tqdm.write(error_message, file=sys.stderr)
+            export_plan_files(
+                daily_plans,
+                args,
+                challenge_ids=current_challenge_segment_ids,
+                routing_failed=True,
+            )
 
     if overall_routing_status_ok:
         export_plan_files(
@@ -5602,6 +5608,8 @@ def main(argv=None):
             except Exception:
                 pass
 
+    return 0 if overall_routing_status_ok else 1
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -187,7 +187,7 @@ def test_failed_output_for_unscheduled_segment(tmp_path):
     with patch('trail_route_ai.plan_review.review_plan'):
         challenge_planner.main(args_list)
 
-    assert not failed_csv.exists()
+    assert failed_csv.exists()
 
 
 def test_failed_output_for_unroutable_segment_if_forced(tmp_path, monkeypatch):
@@ -220,7 +220,7 @@ def test_failed_output_for_unroutable_segment_if_forced(tmp_path, monkeypatch):
         with patch('trail_route_ai.plan_review.review_plan'):
             challenge_planner.main(args_list)
 
-    assert not failed_csv.exists()
+    assert failed_csv.exists()
 
 
 # --- Keep existing tests below ---
@@ -443,7 +443,7 @@ def test_daily_hours_file(tmp_path):
     with patch('trail_route_ai.plan_review.review_plan'):
         challenge_planner.main(args_list)
 
-    assert not failed_csv.exists()
+    assert failed_csv.exists()
 
 
 def test_trailhead_start_in_output(tmp_path):
@@ -542,7 +542,7 @@ def test_infeasible_plan_detection_message(tmp_path, capsys):
         with patch('trail_route_ai.plan_review.review_plan'):
             challenge_planner.main(args_list)
     captured = capsys.readouterr()
-    assert not failed_csv.exists()
+    assert failed_csv.exists()
     assert "impossible to complete all trails" in captured.err
     assert "Failed to schedule" in captured.err
     assert "Unroutable" in captured.err


### PR DESCRIPTION
## Summary
- prefix export files with `failed-` when any segments remain unscheduled
- return non-zero exit codes from `challenge_planner.main` on failure
- update tests expecting failed output files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rocksdict')*

------
https://chatgpt.com/codex/tasks/task_e_6856af95e768832995b04ce1bd2933f3