### PR TITLE
Fix planner config segments path

### DIFF
--- a/config/planner_config.json
+++ b/config/planner_config.json
@@ -23,7 +23,7 @@
   "road_threshold": 0.25,
   "roads": null,
   "rpp_timeout": 5.0,
-  "segments": "data/traildata/trail.json",
+  "segments": "data/traildata/GETChallengeTrailData_v2.json",
   "connector_trails": null,
   "spur_length_thresh": 0.3,
   "spur_road_bonus": 0.25,


### PR DESCRIPTION
## Summary
- update `segments` in planner_config.json to use GETChallengeTrailData_v2.json

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6856b1f5d240832998d2461a13f81067