### PR TITLE
Add snap radius config option

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -415,6 +415,7 @@ class PlannerConfig:
     first_day_segment: Optional[str] = None
     optimizer: str = "greedy2opt"
     draft_daily: bool = False
+    snap_radius_m: float = 25.0
     challenge_target_distance_mi: Optional[float] = None  # Add this
     challenge_target_elevation_ft: Optional[float] = None  # Add this
 


### PR DESCRIPTION
## Summary
- add `snap_radius_m` field to `PlannerConfig`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rocksdict')*

------
https://chatgpt.com/codex/tasks/task_e_6856b7f4029483298dd1b851237966fd