### PR TITLE
Fix reversed edge elevation gain and add elevation efficiency

### DIFF
--- a/src/trail_route_ai/__init__.py
+++ b/src/trail_route_ai/__init__.py
@@ -4,6 +4,8 @@ from .planner_utils import (
     Edge,
     PlanningContext,
     calculate_route_efficiency_score,
+    calculate_route_elevation_efficiency_score,
+    calculate_overall_efficiency_score,
     optimize_route_for_redundancy,
 )
 from .optimizer import (
@@ -17,6 +19,8 @@ __all__ = [
     "Edge",
     "PlanningContext",
     "calculate_route_efficiency_score",
+    "calculate_route_elevation_efficiency_score",
+    "calculate_overall_efficiency_score",
     "optimize_route_for_redundancy",
     "RouteMetrics",
     "is_pareto_improvement",

--- a/src/trail_route_ai/optimizer.py
+++ b/src/trail_route_ai/optimizer.py
@@ -18,6 +18,7 @@ class RouteMetrics:
     new_segment_time: float
     elevation_gain: float
     connectivity: float
+    elevation_efficiency: float
 
 
 def calculate_route_metrics(
@@ -33,6 +34,7 @@ def calculate_route_metrics(
         edges, ctx.pace, ctx.grade, ctx.road_pace
     )
     efficiency = planner_utils.calculate_route_efficiency_score(edges)
+    elev_eff = planner_utils.calculate_route_elevation_efficiency_score(edges)
     redundancy_ratio = 1.0 - efficiency
 
     visited: Set[str] = set()
@@ -58,6 +60,7 @@ def calculate_route_metrics(
         new_segment_time=new_segment_time,
         elevation_gain=elevation_gain,
         connectivity=connectivity,
+        elevation_efficiency=elev_eff,
     )
 
 
@@ -70,12 +73,14 @@ def is_pareto_improvement(a: RouteMetrics, b: RouteMetrics) -> bool:
         and b.redundancy_ratio <= a.redundancy_ratio
         and b.new_segment_time >= a.new_segment_time
         and b.connectivity >= a.connectivity
+        and b.elevation_efficiency >= a.elevation_efficiency
     )
     strictly_better = (
         b.total_time < a.total_time
         or b.redundancy_ratio < a.redundancy_ratio
         or b.new_segment_time > a.new_segment_time
         or b.connectivity > a.connectivity
+        or b.elevation_efficiency > a.elevation_efficiency
     )
     return not_worse and strictly_better
 


### PR DESCRIPTION
## Summary
- fix elevation gain calculation for reversed edges using canonical coordinates
- provide elevation efficiency and overall efficiency scoring helpers
- track elevation efficiency in optimizer metrics and Pareto comparison
- export new helpers in package interface

## Testing
- `ruff check src --fix`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6856caa603548329a8b0e86076cda6ce