### PR TITLE
Add schedule optimizer to balance plans

### DIFF
--- a/tests/test_challenge_planner.py
+++ b/tests/test_challenge_planner.py
@@ -246,7 +246,7 @@ def test_planner_outputs(tmp_path):
     html_out = out_csv.with_suffix(".html")
     assert html_out.exists()
     for row in rows:
-        if row["date"] == "Totals":
+        if row["date"] == "Totals" or float(row["total_activity_time_min"]) == 0:
             continue
         day_str = row["date"].replace("-", "")
         gpx_files = list(gpx_dir.glob(f"{day_str}_part*.gpx"))
@@ -396,9 +396,8 @@ def test_multiday_gpx(tmp_path):
     assert full_gpx.exists()
     with open(full_gpx) as f:
         gpx = gpxpy.parse(f)
-    dates_in_csv = [
-        row["date"] for row in csv.DictReader(open(out_csv)) if row["date"] != "Totals"
-    ]
+    rows = [r for r in csv.DictReader(open(out_csv)) if r["date"] != "Totals"]
+    dates_in_csv = [r["date"] for r in rows if float(r["total_activity_time_min"]) > 0]
     names = [trk.name for trk in gpx.tracks]
     assert names == dates_in_csv
 

--- a/tests/test_official_segment_ids.py
+++ b/tests/test_official_segment_ids.py
@@ -8,9 +8,11 @@ def test_official_data_loads_correctly():
     with open(official_path) as f:
         data = json.load(f)
     official_ids = {
-        str(seg.get("segId") or seg.get("id"))
+        str(seg.get("segId") or seg.get("id") or seg.get("properties", {}).get("segId"))
         for seg in data.get("trailSegments", [])
-        if seg.get("segId") or seg.get("id")
+        if seg.get("segId")
+        or seg.get("id")
+        or seg.get("properties", {}).get("segId")
     }
 
     loaded = planner_utils.load_segments(official_path)

--- a/tests/test_schedule_optimizer.py
+++ b/tests/test_schedule_optimizer.py
@@ -1,0 +1,36 @@
+import datetime
+from trail_route_ai.challenge_planner import ScheduleOptimizer
+
+def make_plan(day, has_activity=True):
+    return {
+        "date": day,
+        "activities": [1] if has_activity else [],
+        "total_activity_time": 10.0 if has_activity else 0.0,
+        "total_drive_time": 0.0,
+        "notes": "",
+    }
+
+def test_optimize_schedule_spreads_plan():
+    start = datetime.date(2024, 7, 1)
+    end = datetime.date(2024, 7, 4)
+    plans = [make_plan(start), make_plan(start + datetime.timedelta(days=1))]
+    budgets = {start + datetime.timedelta(days=i): 60.0 for i in range(4)}
+    optimized = ScheduleOptimizer.optimize_schedule(plans, start, end, budgets)
+    assert len(optimized) == 4
+    assert optimized[0]["date"] == start
+    assert optimized[-1]["date"] == end
+    assert optimized[0]["activities"]
+    assert optimized[-1]["activities"]
+    assert not optimized[1]["activities"] and not optimized[2]["activities"]
+
+def test_optimize_schedule_early_completion():
+    start = datetime.date(2024, 7, 1)
+    end = datetime.date(2024, 7, 4)
+    plans = [make_plan(start), make_plan(start + datetime.timedelta(days=1))]
+    budgets = {start + datetime.timedelta(days=i): 60.0 for i in range(4)}
+    optimized = ScheduleOptimizer.optimize_schedule(plans, start, end, budgets, allow_early_completion=True)
+    assert len(optimized) == 4
+    assert optimized[0]["date"] == start
+    assert optimized[1]["date"] == start + datetime.timedelta(days=1)
+    assert optimized[-1]["date"] == end
+    assert optimized[-1]["activities"] == []


### PR DESCRIPTION
## Summary
- introduce `ScheduleOptimizer` to redistribute daily plans
- expose `--allow-early-completion` flag
- spread plans across the date range when optimization is enabled
- update tests for new behaviour and add unit tests for `ScheduleOptimizer`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cf90e4788329887e93973ff6e7ee