### PR TITLE
Add enhanced route map visualization

### DIFF
--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -3220,7 +3220,12 @@ def write_plan_html(
                 edges.extend(act.get("route_edges", []))
 
         map_img = os.path.join(image_dir, f"map_day_{idx:02d}.png")
-        planner_utils.plot_route_map(edges, map_img)
+        planner_utils.plot_enhanced_route_map(
+            edges,
+            map_img,
+            challenge_ids=challenge_ids,
+            dem_path=dem_path,
+        )
         rel_map = os.path.relpath(map_img, os.path.dirname(path))
         lines.append(f"<img src='{rel_map}' alt='Day {idx} map'>")
 


### PR DESCRIPTION
## Summary
- add `plot_enhanced_route_map` for improved route visuals with labels
- overlay optional elevation shading
- display distance markers and segment labels
- call enhanced plotting function from `write_plan_html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6856d5af35f483298293b9b32fbda1fc