### PR TITLE
Add error code documentation

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1,0 +1,26 @@
+# Planner Error Codes
+
+This document explains the exit codes and common error messages produced by the command line tools in **boise-trails-ai**. Use this as a reference when troubleshooting unexpected planner failures.
+
+## Exit Codes
+
+| Code | Meaning |
+|-----:|---------|
+| `0`  | Planner finished successfully and all routes were generated. |
+| `1`  | Planning failed. One or more errors prevented a complete plan from being produced. |
+
+The planner returns `1` whenever it cannot schedule every required segment (for example if time budgets are too small) or when a critical exception is encountered while loading data files or computing routes.
+
+## Common Error Messages
+
+| Message | Description |
+|---------|-------------|
+| `DijkstraTimeoutError` | Dijkstra pathfinding exceeded the configured time limit. Consider increasing the timeout or simplifying the route. |
+| `Failed to open RocksDB` | The RocksDB cache could not be opened. The planner falls back to an in-memory cache but performance may suffer. |
+| `Configuration file must contain a mapping` | The supplied config file does not parse into key/value pairs. Check that it is valid JSON or YAML. |
+| `Unrecognized segment JSON structure` | The segment data file does not match the expected schema. Verify you are using the provided challenge dataset. |
+| `No track points` | A GPX file contained no track data when running `gpx_to_csv`. |
+| `Routing errors detected. Resolve them before exporting the plan.` | The planner could not build a feasible schedule for all segments. Increase daily time or adjust parameters. |
+| `Error: The following ... challenge segments were not scheduled` | Specific segment IDs were not included in the generated plan. Review the debug log to see why they were skipped. |
+
+Additional error messages may appear when reading files or performing network operations. When troubleshooting, running the planner with the `--verbose` flag will echo these messages to the console and help pinpoint failures.

--- a/README.md
+++ b/README.md
@@ -452,3 +452,7 @@ This script will download the necessary SRTM tiles for the Boise region and then
 * `--buffer_km FLOAT` – Buffer distance around the trail network to include in the DEM (default is 3 km).
 
 Once this DEM file is prepared, you can supply it to the planner with the `--dem` option as shown in the usage example. Having the DEM improves the accuracy of elevation gain calculations and allows the HTML report to display elevation profiles for each route.
+
+## Error Codes and Troubleshooting
+
+See [ERROR_CODES.md](ERROR_CODES.md) for a list of exit codes and common error messages. These notes explain what each error means and provide tips for resolving them.


### PR DESCRIPTION
## Summary
- add `ERROR_CODES.md` with planner exit codes and explanations of common errors
- reference the new guide in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6856dc3591b4832995d195eaadbbc777