### PR TITLE
Validate DEM elevation and progress calculation

### DIFF
--- a/tests/test_progress_pct.py
+++ b/tests/test_progress_pct.py
@@ -2,7 +2,12 @@ import csv
 from unittest.mock import patch
 
 from trail_route_ai import challenge_planner
-from tests.test_challenge_planner import build_edges, setup_planner_test_environment
+from tests.test_challenge_planner import (
+    build_edges,
+    setup_planner_test_environment,
+    create_dem,
+)
+from trail_route_ai import planner_utils
 
 
 def test_planner_reaches_full_progress(tmp_path):
@@ -25,3 +30,34 @@ def test_planner_reaches_full_progress(tmp_path):
     all_descriptions = " ".join(r["plan_description"] for r in rows if r["date"] != "Totals")
     for seg in segments:
         assert seg.seg_id in all_descriptions
+
+
+def test_progress_elevation_pct_full(tmp_path):
+    segments = build_edges(3, prefix="E")
+    dem_path = tmp_path / "dem.tif"
+    create_dem(dem_path)
+    planner_utils.add_elevation_from_dem(segments, str(dem_path))
+    total_gain = round(sum(e.elev_gain_ft for e in segments))
+    total_miles = sum(e.length_mi for e in segments)
+
+    args_list, out_csv = setup_planner_test_environment(
+        tmp_path,
+        segments_data=segments,
+        remaining_ids_str=",".join(e.seg_id for e in segments),
+        extra_args=[
+            "--end-date",
+            "2024-07-03",
+            "--challenge-target-distance-mi",
+            str(total_miles),
+            "--challenge-target-elevation-ft",
+            str(total_gain),
+        ],
+    )
+
+    with patch("trail_route_ai.plan_review.review_plan"):
+        challenge_planner.main(args_list)
+
+    rows = list(csv.DictReader(open(out_csv)))
+    totals = next(r for r in rows if r["date"] == "Totals")
+    assert float(totals["progress_elevation_pct"]) == 100.0
+


### PR DESCRIPTION
## Summary
- validate official segment elevation totals after DEM processing
- calculate progress elevation percentage from unique official gains
- warn when elevation total deviates from the 36k ft target
- regression test for progress_elevation_pct

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dff73e488329a48d8463daef71d2