### PR TITLE
Remove recovery scheduling logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ reviews/
 /plan_images
 /gpx_output_colab
 /gpx
+
+draft_plans/

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -3638,16 +3638,6 @@ def export_plan_files(
                 challenge_ids=challenge_ids,
             )
             notes_final = day_plan.get("notes", "")
-            idx = daily_plans.index(day_plan)
-            if idx > 0:
-                prev_time = daily_plans[idx - 1]["total_activity_time"]
-                cur_time = day_plan["total_activity_time"]
-                if prev_time > cur_time * 1.5:
-                    extra = "easier day to recover after yesterday’s long run"
-                    notes_final = f"{notes_final}; {extra}" if notes_final else extra
-                elif cur_time > prev_time * 1.5:
-                    extra = "big effort after easier day"
-                    notes_final = f"{notes_final}; {extra}" if notes_final else extra
             day_plan["notes"] = notes_final
 
             start_set = {
@@ -3667,15 +3657,6 @@ def export_plan_files(
                 )
             if num_drives_this_day:
                 rationale_parts.append("Includes drive transfers between trail groups.")
-            if idx > 0:
-                prev_time = daily_plans[idx - 1]["total_activity_time"]
-                cur_time = day_plan["total_activity_time"]
-                if prev_time > cur_time * 1.5:
-                    rationale_parts.append("Shorter day planned for recovery.")
-                elif cur_time > prev_time * 1.5:
-                    rationale_parts.append(
-                        "Longer effort scheduled after an easier day."
-                    )
             if not rationale_parts:
                 rationale_parts.append(
                     "Routes selected based on proximity and time budget."


### PR DESCRIPTION
## Summary
- revert draft plan outputs and debug notes
- add draft plans directory to `.gitignore`
- keep simplified export logic without recovery hints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6856e02f23188329af3324723891850f