### PR TITLE
Refine exception handling

### DIFF
--- a/src/trail_route_ai/cache_utils.py
+++ b/src/trail_route_ai/cache_utils.py
@@ -73,7 +73,7 @@ def open_rocksdb(name: str, key: str, read_only: bool = True) -> rocksdict.Rdict
         # For read_only mode, if path exists but Rdict fails to open (e.g. corrupted, not a DB),
         # the exception handling below will catch it.
         return rocksdict.Rdict(path, opts)
-    except (Exception, OSError) as e:
+    except (OSError, rocksdict.DbClosedError) as e:
         # This will catch cases where path exists but is not a valid DB or other Rdict open errors
         # Added "Invalid argument" as it's common for RocksDB open issues on an existing non-DB path or corrupted DB
         if read_only and ("No such file or directory" in str(e) or "does not exist" in str(e) or "NotFound" in str(e) or "Invalid argument" in str(e)):
@@ -90,8 +90,9 @@ def close_rocksdb(db: rocksdict.Rdict | None) -> None:
     if db is not None:
         try:
             db.close()
-        except Exception as e:
+        except (OSError, rocksdict.DbClosedError) as e:
             logger.error("Failed to close RocksDB: %s", e)
+            raise
 
 
 def load_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any) -> Any | None:
@@ -107,7 +108,7 @@ def load_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any) ->
 
     try:
         value_bytes = db_instance.get(key_bytes)
-    except Exception as e:  # pragma: no cover - DB errors
+    except (OSError, rocksdict.DbClosedError) as e:  # pragma: no cover - DB errors
         logger.error("RocksDB read error for %s: %s", source_node, e)
         return None
 
@@ -134,7 +135,7 @@ def save_rocksdb_cache(db_instance: rocksdict.Rdict | None, source_node: Any, da
 
     try:
         db_instance[key_bytes] = value_bytes
-    except Exception as e:  # pragma: no cover - DB errors
+    except (OSError, rocksdict.DbClosedError) as e:  # pragma: no cover - DB errors
         logger.error("RocksDB write error for %s: %s", source_node, e)
 
 

--- a/src/trail_route_ai/challenge_planner.py
+++ b/src/trail_route_ai/challenge_planner.py
@@ -4467,9 +4467,10 @@ def main(argv=None):
                     msg = self.format(record)
                     tqdm.write(msg, file=sys.stderr)  # Ensure tqdm is imported
                     self.flush()
-                except Exception as e:
+                except OSError as e:
                     logger.error("Logging handler error: %s", e)
                     self.handleError(record)
+                    raise
     
         tqdm_handler = TqdmWriteHandler()
         formatter = logging.Formatter("%(levelname)s: %(name)s: %(message)s")
@@ -5943,16 +5944,18 @@ def main(argv=None):
         if "listener" in locals():
             try:
                 listener.stop()
-            except Exception as e:
+            except OSError as e:
                 logger.error("Failed to stop log listener: %s", e)
+                raise
 
         # Close the queue and wait for the queue's thread to finish
         if "log_queue" in locals():
             try:
                 log_queue.close()
                 log_queue.join_thread()
-            except Exception as e:
+            except OSError as e:
                 logger.error("Failed to close log queue: %s", e)
+                raise
 
     return 0 if overall_routing_status_ok else 1
 

--- a/src/trail_route_ai/planner_utils.py
+++ b/src/trail_route_ai/planner_utils.py
@@ -1253,7 +1253,7 @@ def plot_enhanced_route_map(
                         cmap="terrain",
                         alpha=0.3,
                     )
-            except Exception:
+            except (OSError, rasterio.errors.RasterioError):
                 pass
 
     label_positions = []

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -89,3 +89,11 @@ class TestCacheUtilsRocksDB(unittest.TestCase):
             # (Further notes on read-only behavior as in original prompt)
         finally:
             cache_utils.close_rocksdb(db_ro)
+
+    def test_close_rocksdb_raises(self):
+        class BadDB:
+            def close(self):
+                raise OSError("boom")
+
+        with self.assertRaises(OSError):
+            cache_utils.close_rocksdb(BadDB())


### PR DESCRIPTION
## Summary
- narrow raster DEM plotting exceptions
- catch specific RocksDB errors and re-raise on close
- raise errors from log handler and shutdown routines
- test that RocksDB close errors surface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_6856e423c4388329bc1b725c360ba0f3