### PR TITLE
Pin shapely dependency

### DIFF
--- a/requirements.toml
+++ b/requirements.toml
@@ -2,7 +2,7 @@
 dependencies = [
   "pandas",
   "gpxpy",
-  "shapely",
+  "shapely==2.1.1",
   "rtree",
   "networkx",
   "scipy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas
 gpxpy
-shapely
+shapely==2.1.1
 rtree
 networkx
 scipy


### PR DESCRIPTION
## Summary
- pin shapely to 2.1.1 in requirements

## Testing
- `bash run/setup.sh`
- `pytest -q` *(fails: SyntaxError in tests/test_trail_network_analyzer.py)*

------
https://chatgpt.com/codex/tasks/task_e_68570afb37a88329a268a03d06563004